### PR TITLE
feat: switch to native anthropic provider with Databricks model catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,5 +9,4 @@ make build
 make test
 
 ## Reference implementations
-- databricks-codex: same architecture, TOML config
-- databricks-claude: shared pkg/ source (v0.5.0)
+- databricks-claude: shared pkg/ source (v0.5.0), same gateway URL pattern

--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 A Go binary that wraps the [OpenCode CLI](https://opencode.ai) with Databricks AI Gateway OAuth authentication. It patches `~/.config/opencode/config.json`, starts a local token-refreshing proxy, and launches OpenCode — so every request is authenticated through your Databricks workspace without any manual token management.
 
+## Architecture
+
+```
+opencode -> local proxy (OAuth injection) -> Databricks AI Gateway (anthropic endpoint) -> Anthropic
+```
+
+The local proxy intercepts requests from OpenCode, injects a fresh Databricks OAuth token, and forwards them to the AI Gateway's `/anthropic` endpoint.
+
+## Supported models
+
+| Model | Identifier |
+|-------|------------|
+| Claude Opus 4.6 | `claude-opus-4-6` |
+| Claude Opus 4.5 | `claude-opus-4-5` |
+| Claude Sonnet 4.6 | `claude-sonnet-4-6` |
+| Claude Sonnet 4.5 | `claude-sonnet-4-5` |
+| Claude Haiku 4.5 | `claude-haiku-4-5` |
+
+Default: `anthropic/claude-sonnet-4-6`
+
 ## Prerequisites
 
 - [Go 1.22+](https://go.dev/dl/)
@@ -40,7 +60,7 @@ make build
 |------|-------------|
 | `--profile` | Databricks CLI profile (saved for future sessions; default: env or "DEFAULT") |
 | `--upstream` | Override the AI Gateway URL (default: auto-discovered) |
-| `--model` | Model to use (default: "databricks-gpt-5-4") |
+| `--model` | Databricks model (claude-opus-4-6, claude-sonnet-4-6, etc.; default: "anthropic/claude-sonnet-4-6") |
 | `--print-env` | Print resolved configuration and exit (token redacted) |
 | `--verbose`, `-v` | Enable debug logging to stderr |
 | `--log-file` | Write debug logs to a file (combinable with --verbose) |
@@ -53,11 +73,18 @@ make build
 ## How it works
 
 1. Authenticates with Databricks using the CLI profile
-2. Discovers the workspace host and constructs the AI Gateway URL
-3. Patches `~/.config/opencode/config.json` to point at a local proxy
-4. Starts a local HTTP proxy that injects a fresh OAuth token on every request
-5. Launches `opencode` as a child process
-6. Restores `config.json` on exit (crash-safe via backup file)
+2. Discovers the workspace host and resolves the workspace ID via SCIM
+3. Constructs the AI Gateway URL: `https://{workspaceId}.ai-gateway.cloud.databricks.com/anthropic`
+4. Patches `~/.config/opencode/config.json` to configure the native `anthropic` provider pointing at a local proxy
+5. Starts a local HTTP proxy that injects a fresh OAuth token on every request
+6. Launches `opencode` as a child process
+7. Restores `config.json` on exit (crash-safe via sidecar file)
+
+The config patch injects into `provider.anthropic`:
+- Sets `options.baseURL` to the local proxy address
+- Sets `options.apiKey` to a placeholder
+- Adds the 5 Databricks Claude model entries to `models`
+- On restore, only the injected keys are removed (user config is preserved)
 
 Multiple concurrent sessions are supported via a session registry — each proxy hands off config ownership cleanly on exit.
 

--- a/config_test.go
+++ b/config_test.go
@@ -34,27 +34,27 @@ func readJSONFile(t *testing.T, path string) map[string]interface{} {
 func TestConfigManagerSetupCreatesConfig(t *testing.T) {
 	cm, _ := setupTestConfigManager(t)
 
-	if err := cm.Setup("http://127.0.0.1:9000", "gpt-5-4", "databricks-proxy", false); err != nil {
+	if err := cm.Setup("http://127.0.0.1:9000", "anthropic/claude-sonnet-4-6", "databricks-oauth-proxy", false); err != nil {
 		t.Fatalf("Setup: %v", err)
 	}
 
 	m := readJSONFile(t, cm.config.Path())
 
-	if m["model"] != "databricks-proxy/gpt-5-4" {
-		t.Errorf("model = %v, want %q", m["model"], "databricks-proxy/gpt-5-4")
+	if m["model"] != "anthropic/claude-sonnet-4-6" {
+		t.Errorf("model = %v, want %q", m["model"], "anthropic/claude-sonnet-4-6")
 	}
 
 	providers, _ := m["provider"].(map[string]interface{})
-	dbProxy, _ := providers["databricks-proxy"].(map[string]interface{})
-	if dbProxy == nil {
-		t.Fatal("databricks-proxy provider not found")
+	anthropic, _ := providers["anthropic"].(map[string]interface{})
+	if anthropic == nil {
+		t.Fatal("anthropic provider not found")
 	}
-	options, _ := dbProxy["options"].(map[string]interface{})
+	options, _ := anthropic["options"].(map[string]interface{})
 	if options == nil {
-		t.Fatal("databricks-proxy options not found")
+		t.Fatal("anthropic options not found")
 	}
-	if options["baseURL"] != "http://127.0.0.1:9000/v1" {
-		t.Errorf("options.baseURL = %v, want %q", options["baseURL"], "http://127.0.0.1:9000/v1")
+	if options["baseURL"] != "http://127.0.0.1:9000" {
+		t.Errorf("options.baseURL = %v, want %q", options["baseURL"], "http://127.0.0.1:9000")
 	}
 }
 
@@ -67,7 +67,7 @@ func TestConfigManagerSetupPreservesExisting(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
-	if err := cm.Setup("http://127.0.0.1:8080", "model-a", "key", false); err != nil {
+	if err := cm.Setup("http://127.0.0.1:8080", "anthropic/claude-sonnet-4-6", "key", false); err != nil {
 		t.Fatalf("Setup: %v", err)
 	}
 
@@ -82,8 +82,8 @@ func TestConfigManagerSetupPreservesExisting(t *testing.T) {
 	if providers["openai"] == nil {
 		t.Error("openai provider was not preserved")
 	}
-	if providers["databricks-proxy"] == nil {
-		t.Error("databricks-proxy not injected")
+	if providers["anthropic"] == nil {
+		t.Error("anthropic not injected")
 	}
 }
 
@@ -95,7 +95,7 @@ func TestConfigManagerRestore(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
-	if err := cm.Setup("http://127.0.0.1:5000", "m", "k", false); err != nil {
+	if err := cm.Setup("http://127.0.0.1:5000", "anthropic/claude-sonnet-4-6", "k", false); err != nil {
 		t.Fatalf("Setup: %v", err)
 	}
 
@@ -142,7 +142,7 @@ func TestConfigManagerCrashRecovery(t *testing.T) {
 	}
 
 	// Simulate first session: setup but no restore (crash).
-	if err := cm.Setup("http://127.0.0.1:5000", "m", "k", false); err != nil {
+	if err := cm.Setup("http://127.0.0.1:5000", "anthropic/claude-sonnet-4-6", "k", false); err != nil {
 		t.Fatalf("Setup: %v", err)
 	}
 
@@ -152,13 +152,16 @@ func TestConfigManagerCrashRecovery(t *testing.T) {
 	}
 
 	// New session setup should recover: surgical restore first, then re-patch.
-	if err := cm.Setup("http://127.0.0.1:6000", "m2", "k2", false); err != nil {
+	if err := cm.Setup("http://127.0.0.1:6000", "anthropic/claude-opus-4-5", "k2", false); err != nil {
 		t.Fatalf("Setup after crash: %v", err)
 	}
 
 	m := readJSONFile(t, cm.config.Path())
-	if m["model"] != "databricks-proxy/m2" {
-		t.Errorf("model = %v, want %q", m["model"], "databricks-proxy/m2")
+	// Model was set during first session and preserved (not forced).
+	// After crash recovery the first session's model is restored (absent -> removed),
+	// then re-patched with the new session's model.
+	if m["model"] != "anthropic/claude-opus-4-5" {
+		t.Errorf("model = %v, want %q", m["model"], "anthropic/claude-opus-4-5")
 	}
 
 	// Original user config should still be there.
@@ -177,7 +180,7 @@ func TestConfigManagerPreservesUserModel(t *testing.T) {
 	}
 
 	// Setup without forceModel — should preserve user's model.
-	if err := cm.Setup("http://127.0.0.1:5000", "gpt-5-4", "k", false); err != nil {
+	if err := cm.Setup("http://127.0.0.1:5000", "anthropic/claude-sonnet-4-6", "k", false); err != nil {
 		t.Fatalf("Setup: %v", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -78,7 +78,7 @@ func main() {
 	log.Printf("databricks-opencode: using profile: %s", profile)
 
 	// --- Resolve model ---
-	// Resolution chain: --model flag → saved state → "databricks-claude-sonnet-4-6" default.
+	// Resolution chain: --model flag → saved state → "anthropic/claude-sonnet-4-6" default.
 	// When --model is explicitly passed, save it for future sessions.
 	modelExplicit := model != ""
 	if model == "" {
@@ -88,7 +88,7 @@ func main() {
 		}
 	}
 	if model == "" {
-		model = "databricks-claude-sonnet-4-6"
+		model = "anthropic/claude-sonnet-4-6"
 	}
 	if modelExplicit {
 		saved := loadState()
@@ -173,13 +173,9 @@ func main() {
 
 	// --- Patch config.json to point OpenCode at the local proxy ---
 	cm := NewConfigManager()
-	if err := cm.Setup(proxyAddr, model, "databricks-proxy", modelExplicit); err != nil {
+	if err := cm.Setup(proxyAddr, model, "databricks-oauth-proxy", modelExplicit); err != nil {
 		log.Fatalf("databricks-opencode: failed to patch config.json: %v", err)
 	}
-
-	// Set OPENAI_API_KEY as a placeholder — the proxy overwrites the
-	// Authorization header with a live Databricks token per request.
-	os.Setenv("OPENAI_API_KEY", "databricks-proxy")
 
 	log.Printf("databricks-opencode: launching opencode")
 
@@ -327,7 +323,7 @@ Usage:
 Databricks-OpenCode Flags:
   --profile string      Databricks CLI profile (saved for future sessions; default: env or "DEFAULT")
   --upstream string     Override the AI Gateway URL (default: auto-discovered)
-  --model string        Model to use (default: "databricks-claude-sonnet-4-6")
+  --model string        Databricks model (claude-opus-4-6, claude-sonnet-4-6, etc.; default: "anthropic/claude-sonnet-4-6")
   --print-env           Print resolved configuration and exit (token redacted)
   --verbose, -v         Enable debug logging to stderr
   --log-file string     Write debug logs to a file (combinable with --verbose)

--- a/pkg/jsonconfig/jsonconfig.go
+++ b/pkg/jsonconfig/jsonconfig.go
@@ -15,12 +15,21 @@ import (
 // sentinel is used to distinguish "key was absent" from "key was empty string".
 var absent = struct{}{}
 
+// databricksModels are the model keys we inject into provider.anthropic.models.
+var databricksModels = []string{
+	"claude-opus-4-6",
+	"claude-opus-4-5",
+	"claude-sonnet-4-6",
+	"claude-sonnet-4-5",
+	"claude-haiku-4-5",
+}
+
 // Config reads, patches, and restores the OpenCode config.json file.
 type Config struct {
-	path         string
-	backupPath   string
-	sidecarPath  string
-	originals    map[string]interface{} // key -> original value, or absent sentinel
+	path        string
+	backupPath  string
+	sidecarPath string
+	originals   map[string]interface{} // key -> original value, or absent sentinel
 }
 
 // New creates a Config that manages ~/.config/opencode/opencode.json.
@@ -100,22 +109,41 @@ func (c *Config) SaveOriginals() error {
 		c.originals["model"] = absent
 	}
 
-	// Snapshot provider.databricks-proxy key.
+	// Snapshot provider.anthropic.options.baseURL and apiKey.
 	providers, _ := config["provider"].(map[string]interface{})
-	if providers != nil {
-		if v, ok := providers["databricks-proxy"]; ok {
-			c.originals["provider.databricks-proxy"] = v
-		} else {
-			c.originals["provider.databricks-proxy"] = absent
-		}
+	anthropic, _ := getMap(providers, "anthropic")
+	options, _ := getMap(anthropic, "options")
+
+	if v, ok := options["baseURL"]; ok {
+		c.originals["anthropic.options.baseURL"] = v
 	} else {
-		c.originals["provider.databricks-proxy"] = absent
+		c.originals["anthropic.options.baseURL"] = absent
+	}
+
+	if v, ok := options["apiKey"]; ok {
+		c.originals["anthropic.options.apiKey"] = v
+	} else {
+		c.originals["anthropic.options.apiKey"] = absent
+	}
+
+	// Snapshot which Databricks model keys existed before.
+	models, _ := getMap(anthropic, "models")
+	for _, m := range databricksModels {
+		key := "anthropic.models." + m
+		if _, ok := models[m]; ok {
+			c.originals[key] = true // existed
+		} else {
+			c.originals[key] = absent
+		}
 	}
 
 	return c.writeSidecar()
 }
 
-// Patch injects the databricks-proxy provider and optionally sets the model.
+// Patch injects the anthropic provider config and optionally sets the model.
+// proxyURL is the local proxy address (e.g. http://127.0.0.1:8080).
+// modelName is the full model identifier (e.g. anthropic/claude-sonnet-4-6).
+// apiKey is a placeholder key for the proxy.
 // If forceModel is true, the model is always written (explicit --model flag).
 // If forceModel is false, the model is only set if absent (preserve-if-present).
 func (c *Config) Patch(proxyURL, modelName, apiKey string, forceModel bool) error {
@@ -130,30 +158,44 @@ func (c *Config) Patch(proxyURL, modelName, apiKey string, forceModel bool) erro
 		providers = make(map[string]interface{})
 	}
 
-	// Inject the databricks-proxy provider (always overwrite — we own this key).
-	// Uses @ai-sdk/anthropic with authToken (sends Authorization: Bearer header
-	// which the local proxy expects, vs apiKey which sends x-api-key).
-	providers["databricks-proxy"] = map[string]interface{}{
-		"npm":  "@ai-sdk/anthropic",
-		"name": "Databricks AI Gateway",
-		"options": map[string]interface{}{
-			"baseURL":   proxyURL + "/v1",
-			"authToken": apiKey,
-		},
-		"models": map[string]interface{}{
-			modelName: map[string]interface{}{
-				"name": modelName,
-			},
-		},
+	// Ensure provider.anthropic exists (preserve user's existing keys).
+	anthropic, _ := providers["anthropic"].(map[string]interface{})
+	if anthropic == nil {
+		anthropic = make(map[string]interface{})
 	}
+
+	// Ensure options map exists (preserve user's existing options like timeout).
+	options, _ := anthropic["options"].(map[string]interface{})
+	if options == nil {
+		options = make(map[string]interface{})
+	}
+
+	// Inject our managed keys into options.
+	options["baseURL"] = proxyURL
+	options["apiKey"] = apiKey
+	anthropic["options"] = options
+
+	// Ensure models map exists (preserve user's existing models).
+	models, _ := anthropic["models"].(map[string]interface{})
+	if models == nil {
+		models = make(map[string]interface{})
+	}
+
+	// Add the 5 Databricks model keys.
+	for _, m := range databricksModels {
+		models[m] = map[string]interface{}{}
+	}
+	anthropic["models"] = models
+
+	providers["anthropic"] = anthropic
 	config["provider"] = providers
 
 	// Set the active model: preserve-if-present unless forced.
 	if forceModel {
-		config["model"] = "databricks-proxy/" + modelName
+		config["model"] = modelName
 	} else {
 		if _, exists := config["model"]; !exists {
-			config["model"] = "databricks-proxy/" + modelName
+			config["model"] = modelName
 		}
 	}
 
@@ -161,7 +203,7 @@ func (c *Config) Patch(proxyURL, modelName, apiKey string, forceModel bool) erro
 }
 
 // Restore surgically removes only the keys we manage and restores originals.
-// Removes provider.databricks-proxy and restores model to its original value.
+// Removes injected anthropic options and model keys, restores model to its original value.
 func (c *Config) Restore() error {
 	// Load originals from sidecar if not in memory.
 	if len(c.originals) == 0 {
@@ -189,17 +231,61 @@ func (c *Config) Restore() error {
 		}
 	}
 
-	// Remove provider.databricks-proxy.
-	if providers, ok := config["provider"].(map[string]interface{}); ok {
-		if orig, exists := c.originals["provider.databricks-proxy"]; exists {
-			if orig == absent {
-				delete(providers, "databricks-proxy")
-			} else {
-				providers["databricks-proxy"] = orig
+	// Restore anthropic provider keys.
+	providers, _ := config["provider"].(map[string]interface{})
+	if providers != nil {
+		anthropic, _ := providers["anthropic"].(map[string]interface{})
+		if anthropic != nil {
+			options, _ := anthropic["options"].(map[string]interface{})
+			if options != nil {
+				// Restore baseURL.
+				if orig, ok := c.originals["anthropic.options.baseURL"]; ok {
+					if orig == absent {
+						delete(options, "baseURL")
+					} else {
+						options["baseURL"] = orig
+					}
+				}
+				// Restore apiKey.
+				if orig, ok := c.originals["anthropic.options.apiKey"]; ok {
+					if orig == absent {
+						delete(options, "apiKey")
+					} else {
+						options["apiKey"] = orig
+					}
+				}
+				if len(options) == 0 {
+					delete(anthropic, "options")
+				} else {
+					anthropic["options"] = options
+				}
 			}
-		} else {
-			delete(providers, "databricks-proxy")
+
+			// Remove only our injected model keys.
+			models, _ := anthropic["models"].(map[string]interface{})
+			if models != nil {
+				for _, m := range databricksModels {
+					key := "anthropic.models." + m
+					if orig, ok := c.originals[key]; ok && orig == absent {
+						delete(models, m)
+					}
+					// If it existed before, leave it alone.
+				}
+				if len(models) == 0 {
+					delete(anthropic, "models")
+				} else {
+					anthropic["models"] = models
+				}
+			}
+
+			// If anthropic provider is now empty, remove it.
+			if len(anthropic) == 0 {
+				delete(providers, "anthropic")
+			} else {
+				providers["anthropic"] = anthropic
+			}
 		}
+
 		// If providers map is now empty, remove it.
 		if len(providers) == 0 {
 			delete(config, "provider")
@@ -222,7 +308,7 @@ func (c *Config) Backup() error {
 	return c.WriteSentinel()
 }
 
-// UpdateProxyURL updates only the baseURL in the existing databricks-proxy provider.
+// UpdateProxyURL updates only the baseURL in the existing anthropic provider options.
 func (c *Config) UpdateProxyURL(proxyURL string) error {
 	config, err := c.readConfig()
 	if err != nil {
@@ -234,18 +320,18 @@ func (c *Config) UpdateProxyURL(proxyURL string) error {
 		return fmt.Errorf("no provider section in config")
 	}
 
-	dbProxy, _ := providers["databricks-proxy"].(map[string]interface{})
-	if dbProxy == nil {
-		return fmt.Errorf("no databricks-proxy provider in config")
+	anthropic, _ := providers["anthropic"].(map[string]interface{})
+	if anthropic == nil {
+		return fmt.Errorf("no anthropic provider in config")
 	}
 
-	options, _ := dbProxy["options"].(map[string]interface{})
+	options, _ := anthropic["options"].(map[string]interface{})
 	if options == nil {
 		options = make(map[string]interface{})
 	}
 	options["baseURL"] = proxyURL
-	dbProxy["options"] = options
-	providers["databricks-proxy"] = dbProxy
+	anthropic["options"] = options
+	providers["anthropic"] = anthropic
 	config["provider"] = providers
 
 	return c.writeConfig(config)
@@ -260,10 +346,17 @@ func (c *Config) cleanup() {
 
 // sidecarData is the JSON schema for the sidecar file.
 type sidecarData struct {
-	Model              interface{} `json:"model"`
-	ModelAbsent        bool        `json:"model_absent"`
-	ProviderDBProxy    interface{} `json:"provider_databricks_proxy"`
-	ProviderDBPAbsent  bool        `json:"provider_databricks_proxy_absent"`
+	Model        interface{} `json:"model"`
+	ModelAbsent  bool        `json:"model_absent"`
+
+	BaseURL        interface{} `json:"anthropic_options_baseURL"`
+	BaseURLAbsent  bool        `json:"anthropic_options_baseURL_absent"`
+	APIKey         interface{} `json:"anthropic_options_apiKey"`
+	APIKeyAbsent   bool        `json:"anthropic_options_apiKey_absent"`
+
+	// Which Databricks model keys existed before patching.
+	// Maps model name -> true if existed, omitted if absent.
+	ExistingModels map[string]bool `json:"existing_models,omitempty"`
 }
 
 // writeSidecar persists originals to disk for crash recovery.
@@ -278,11 +371,27 @@ func (c *Config) writeSidecar() error {
 		}
 	}
 
-	if v, ok := c.originals["provider.databricks-proxy"]; ok {
+	if v, ok := c.originals["anthropic.options.baseURL"]; ok {
 		if v == absent {
-			sd.ProviderDBPAbsent = true
+			sd.BaseURLAbsent = true
 		} else {
-			sd.ProviderDBProxy = v
+			sd.BaseURL = v
+		}
+	}
+
+	if v, ok := c.originals["anthropic.options.apiKey"]; ok {
+		if v == absent {
+			sd.APIKeyAbsent = true
+		} else {
+			sd.APIKey = v
+		}
+	}
+
+	sd.ExistingModels = make(map[string]bool)
+	for _, m := range databricksModels {
+		key := "anthropic.models." + m
+		if v, ok := c.originals[key]; ok && v != absent {
+			sd.ExistingModels[m] = true
 		}
 	}
 
@@ -314,13 +423,37 @@ func (c *Config) loadSidecar() error {
 		c.originals["model"] = sd.Model
 	}
 
-	if sd.ProviderDBPAbsent {
-		c.originals["provider.databricks-proxy"] = absent
+	if sd.BaseURLAbsent {
+		c.originals["anthropic.options.baseURL"] = absent
 	} else {
-		c.originals["provider.databricks-proxy"] = sd.ProviderDBProxy
+		c.originals["anthropic.options.baseURL"] = sd.BaseURL
+	}
+
+	if sd.APIKeyAbsent {
+		c.originals["anthropic.options.apiKey"] = absent
+	} else {
+		c.originals["anthropic.options.apiKey"] = sd.APIKey
+	}
+
+	for _, m := range databricksModels {
+		key := "anthropic.models." + m
+		if sd.ExistingModels[m] {
+			c.originals[key] = true
+		} else {
+			c.originals[key] = absent
+		}
 	}
 
 	return nil
+}
+
+// getMap safely extracts a nested map from a parent map.
+func getMap(parent map[string]interface{}, key string) (map[string]interface{}, bool) {
+	if parent == nil {
+		return nil, false
+	}
+	v, ok := parent[key].(map[string]interface{})
+	return v, ok
 }
 
 // readConfig reads the config file and returns a parsed map.

--- a/pkg/jsonconfig/jsonconfig_test.go
+++ b/pkg/jsonconfig/jsonconfig_test.go
@@ -32,7 +32,7 @@ func readJSON(t *testing.T, path string) map[string]interface{} {
 func TestPatchEmptyFile(t *testing.T) {
 	c := setupTestConfig(t)
 
-	if err := c.Patch("http://127.0.0.1:9000", "gpt-5-4", "databricks-proxy", false); err != nil {
+	if err := c.Patch("http://127.0.0.1:9000", "anthropic/claude-sonnet-4-6", "databricks-oauth-proxy", false); err != nil {
 		t.Fatalf("Patch: %v", err)
 	}
 
@@ -40,35 +40,36 @@ func TestPatchEmptyFile(t *testing.T) {
 
 	// Check model field — should be set when absent.
 	model, ok := m["model"].(string)
-	if !ok || model != "databricks-proxy/gpt-5-4" {
-		t.Errorf("model = %q, want %q", model, "databricks-proxy/gpt-5-4")
+	if !ok || model != "anthropic/claude-sonnet-4-6" {
+		t.Errorf("model = %q, want %q", model, "anthropic/claude-sonnet-4-6")
 	}
 
 	// Check provider injected.
 	providers, _ := m["provider"].(map[string]interface{})
-	dbProxy, _ := providers["databricks-proxy"].(map[string]interface{})
-	if dbProxy == nil {
-		t.Fatal("databricks-proxy provider not found")
+	anthropic, _ := providers["anthropic"].(map[string]interface{})
+	if anthropic == nil {
+		t.Fatal("anthropic provider not found")
 	}
-	options, _ := dbProxy["options"].(map[string]interface{})
+	options, _ := anthropic["options"].(map[string]interface{})
 	if options == nil {
-		t.Fatal("databricks-proxy options not found")
+		t.Fatal("anthropic options not found")
 	}
-	if options["baseURL"] != "http://127.0.0.1:9000/v1" {
-		t.Errorf("options.baseURL = %v, want %q", options["baseURL"], "http://127.0.0.1:9000/v1")
+	if options["baseURL"] != "http://127.0.0.1:9000" {
+		t.Errorf("options.baseURL = %v, want %q", options["baseURL"], "http://127.0.0.1:9000")
 	}
-	if options["authToken"] != "databricks-proxy" {
-		t.Errorf("options.authToken = %v, want %q", options["authToken"], "databricks-proxy")
+	if options["apiKey"] != "databricks-oauth-proxy" {
+		t.Errorf("options.apiKey = %v, want %q", options["apiKey"], "databricks-oauth-proxy")
 	}
-	if dbProxy["npm"] != "@ai-sdk/anthropic" {
-		t.Errorf("npm = %v, want %q", dbProxy["npm"], "@ai-sdk/anthropic")
-	}
-	models, _ := dbProxy["models"].(map[string]interface{})
+
+	// Check all 5 Databricks models are injected.
+	models, _ := anthropic["models"].(map[string]interface{})
 	if models == nil {
-		t.Fatal("databricks-proxy models not found")
+		t.Fatal("anthropic models not found")
 	}
-	if models["gpt-5-4"] == nil {
-		t.Error("models[\"gpt-5-4\"] not found")
+	for _, m := range databricksModels {
+		if models[m] == nil {
+			t.Errorf("models[%q] not found", m)
+		}
 	}
 }
 
@@ -94,7 +95,7 @@ func TestPatchPreservesUserConfig(t *testing.T) {
 		t.Fatalf("write existing config: %v", err)
 	}
 
-	if err := c.Patch("http://127.0.0.1:8080", "claude-4", "db-key", false); err != nil {
+	if err := c.Patch("http://127.0.0.1:8080", "anthropic/claude-sonnet-4-6", "db-key", false); err != nil {
 		t.Fatalf("Patch: %v", err)
 	}
 
@@ -105,8 +106,8 @@ func TestPatchPreservesUserConfig(t *testing.T) {
 	if _, ok := providers["openai"]; !ok {
 		t.Error("openai provider was not preserved")
 	}
-	if _, ok := providers["databricks-proxy"]; !ok {
-		t.Error("databricks-proxy provider was not injected")
+	if _, ok := providers["anthropic"]; !ok {
+		t.Error("anthropic provider was not injected")
 	}
 
 	// Verify commands preserved.
@@ -132,7 +133,7 @@ func TestPatchPreservesExistingModel(t *testing.T) {
 	}
 
 	// Patch without forceModel — should preserve existing model.
-	if err := c.Patch("http://127.0.0.1:9000", "gpt-5-4", "key", false); err != nil {
+	if err := c.Patch("http://127.0.0.1:9000", "anthropic/claude-sonnet-4-6", "key", false); err != nil {
 		t.Fatalf("Patch: %v", err)
 	}
 
@@ -152,13 +153,13 @@ func TestPatchForceModelOverridesExisting(t *testing.T) {
 	}
 
 	// Patch with forceModel — should override.
-	if err := c.Patch("http://127.0.0.1:9000", "gpt-5-4", "key", true); err != nil {
+	if err := c.Patch("http://127.0.0.1:9000", "anthropic/claude-sonnet-4-6", "key", true); err != nil {
 		t.Fatalf("Patch: %v", err)
 	}
 
 	m := readJSON(t, c.Path())
-	if m["model"] != "databricks-proxy/gpt-5-4" {
-		t.Errorf("model = %v, want %q (forceModel should override)", m["model"], "databricks-proxy/gpt-5-4")
+	if m["model"] != "anthropic/claude-sonnet-4-6" {
+		t.Errorf("model = %v, want %q (forceModel should override)", m["model"], "anthropic/claude-sonnet-4-6")
 	}
 }
 
@@ -171,13 +172,13 @@ func TestPatchSetsModelWhenAbsent(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 
-	if err := c.Patch("http://127.0.0.1:9000", "gpt-5-4", "key", false); err != nil {
+	if err := c.Patch("http://127.0.0.1:9000", "anthropic/claude-sonnet-4-6", "key", false); err != nil {
 		t.Fatalf("Patch: %v", err)
 	}
 
 	m := readJSON(t, c.Path())
-	if m["model"] != "databricks-proxy/gpt-5-4" {
-		t.Errorf("model = %v, want %q (should set when absent)", m["model"], "databricks-proxy/gpt-5-4")
+	if m["model"] != "anthropic/claude-sonnet-4-6" {
+		t.Errorf("model = %v, want %q (should set when absent)", m["model"], "anthropic/claude-sonnet-4-6")
 	}
 }
 
@@ -203,13 +204,13 @@ func TestSurgicalRestore(t *testing.T) {
 	}
 
 	// Patch.
-	if err := c.Patch("http://127.0.0.1:5000", "test-model", "key", false); err != nil {
+	if err := c.Patch("http://127.0.0.1:5000", "anthropic/claude-sonnet-4-6", "key", false); err != nil {
 		t.Fatalf("Patch: %v", err)
 	}
 
 	// Verify patched.
 	patched := readJSON(t, c.Path())
-	if patched["model"] != "databricks-proxy/test-model" {
+	if patched["model"] != "anthropic/claude-sonnet-4-6" {
 		t.Fatalf("expected patched model, got %v", patched["model"])
 	}
 
@@ -251,7 +252,7 @@ func TestRestoreOnlyRemovesManagedKeys(t *testing.T) {
 	if err := c.SaveOriginals(); err != nil {
 		t.Fatalf("SaveOriginals: %v", err)
 	}
-	if err := c.Patch("http://127.0.0.1:5000", "m", "k", false); err != nil {
+	if err := c.Patch("http://127.0.0.1:5000", "anthropic/claude-sonnet-4-6", "k", false); err != nil {
 		t.Fatalf("Patch: %v", err)
 	}
 
@@ -286,10 +287,9 @@ func TestRestoreOnlyRemovesManagedKeys(t *testing.T) {
 	if _, exists := restored["model"]; exists {
 		t.Error("model should be removed after restore")
 	}
-	if providers, ok := restored["provider"].(map[string]interface{}); ok {
-		if _, exists := providers["databricks-proxy"]; exists {
-			t.Error("databricks-proxy provider should be removed after restore")
-		}
+	// anthropic provider should be fully removed (was absent before patch).
+	if _, exists := restored["provider"]; exists {
+		t.Error("provider should not exist after restore (was absent before patch)")
 	}
 }
 
@@ -308,7 +308,7 @@ func TestRestorePreservesOriginalModel(t *testing.T) {
 	}
 
 	// Force-patch with our model.
-	if err := c.Patch("http://127.0.0.1:5000", "m", "k", true); err != nil {
+	if err := c.Patch("http://127.0.0.1:5000", "anthropic/claude-sonnet-4-6", "k", true); err != nil {
 		t.Fatalf("Patch: %v", err)
 	}
 
@@ -338,7 +338,7 @@ func TestCrashRecoverySurgical(t *testing.T) {
 	if err := c.WriteSentinel(); err != nil {
 		t.Fatalf("WriteSentinel: %v", err)
 	}
-	if err := c.Patch("http://127.0.0.1:5000", "m", "k", false); err != nil {
+	if err := c.Patch("http://127.0.0.1:5000", "anthropic/claude-sonnet-4-6", "k", false); err != nil {
 		t.Fatalf("Patch: %v", err)
 	}
 
@@ -371,7 +371,7 @@ func TestUpdateProxyURL(t *testing.T) {
 	c := setupTestConfig(t)
 
 	// Patch first.
-	if err := c.Patch("http://127.0.0.1:5000", "model-a", "key", false); err != nil {
+	if err := c.Patch("http://127.0.0.1:5000", "anthropic/claude-sonnet-4-6", "key", false); err != nil {
 		t.Fatalf("Patch: %v", err)
 	}
 
@@ -382,17 +382,17 @@ func TestUpdateProxyURL(t *testing.T) {
 
 	m := readJSON(t, c.Path())
 	providers, _ := m["provider"].(map[string]interface{})
-	dbProxy, _ := providers["databricks-proxy"].(map[string]interface{})
-	options, _ := dbProxy["options"].(map[string]interface{})
+	anthropic, _ := providers["anthropic"].(map[string]interface{})
+	options, _ := anthropic["options"].(map[string]interface{})
 	if options == nil {
-		t.Fatal("databricks-proxy options not found after UpdateProxyURL")
+		t.Fatal("anthropic options not found after UpdateProxyURL")
 	}
 	if options["baseURL"] != "http://127.0.0.1:6000" {
 		t.Errorf("options.baseURL = %v, want %q", options["baseURL"], "http://127.0.0.1:6000")
 	}
 
 	// Model should be unchanged.
-	if m["model"] != "databricks-proxy/model-a" {
+	if m["model"] != "anthropic/claude-sonnet-4-6" {
 		t.Errorf("model changed unexpectedly: %v", m["model"])
 	}
 }
@@ -415,7 +415,7 @@ func TestInvalidJSONC(t *testing.T) {
 	}
 
 	// Patch should parse JSONC correctly.
-	if err := c.Patch("http://127.0.0.1:7000", "model-b", "key", false); err != nil {
+	if err := c.Patch("http://127.0.0.1:7000", "anthropic/claude-sonnet-4-6", "key", false); err != nil {
 		t.Fatalf("Patch with JSONC: %v", err)
 	}
 
@@ -431,7 +431,93 @@ func TestInvalidJSONC(t *testing.T) {
 	if providers["openai"] == nil {
 		t.Error("openai provider lost after JSONC patch")
 	}
-	if providers["databricks-proxy"] == nil {
-		t.Error("databricks-proxy not injected")
+	if providers["anthropic"] == nil {
+		t.Error("anthropic not injected")
+	}
+}
+
+func TestRestorePreservesExistingAnthropicConfig(t *testing.T) {
+	c := setupTestConfig(t)
+
+	// User already has an anthropic provider with their own model and timeout.
+	original := `{
+  "provider": {
+    "anthropic": {
+      "options": {
+        "timeout": 30000
+      },
+      "models": {
+        "my-custom-model": {"name": "My Model"}
+      }
+    }
+  }
+}`
+	if err := os.WriteFile(c.Path(), []byte(original), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Snapshot + Patch.
+	if err := c.SaveOriginals(); err != nil {
+		t.Fatalf("SaveOriginals: %v", err)
+	}
+	if err := c.Patch("http://127.0.0.1:5000", "anthropic/claude-sonnet-4-6", "k", false); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	// Verify patched: should have our keys plus user's keys.
+	patched := readJSON(t, c.Path())
+	providers, _ := patched["provider"].(map[string]interface{})
+	anthropic, _ := providers["anthropic"].(map[string]interface{})
+	options, _ := anthropic["options"].(map[string]interface{})
+	if options["baseURL"] != "http://127.0.0.1:5000" {
+		t.Errorf("baseURL = %v, want proxy URL", options["baseURL"])
+	}
+	// User's timeout should still be there.
+	if options["timeout"] == nil {
+		t.Error("user's timeout option should be preserved during patch")
+	}
+	// User's custom model should still be there.
+	models, _ := anthropic["models"].(map[string]interface{})
+	if models["my-custom-model"] == nil {
+		t.Error("user's custom model should be preserved during patch")
+	}
+	// Our models should be there.
+	if models["claude-sonnet-4-6"] == nil {
+		t.Error("claude-sonnet-4-6 should be injected")
+	}
+
+	// Restore.
+	if err := c.Restore(); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	restored := readJSON(t, c.Path())
+	rProviders, _ := restored["provider"].(map[string]interface{})
+	rAnthropic, _ := rProviders["anthropic"].(map[string]interface{})
+	if rAnthropic == nil {
+		t.Fatal("anthropic provider should still exist after restore (was present before)")
+	}
+	rOptions, _ := rAnthropic["options"].(map[string]interface{})
+	// baseURL and apiKey should be removed (were absent before).
+	if _, exists := rOptions["baseURL"]; exists {
+		t.Error("baseURL should be removed after restore (was absent before)")
+	}
+	if _, exists := rOptions["apiKey"]; exists {
+		t.Error("apiKey should be removed after restore (was absent before)")
+	}
+	// User's timeout should survive.
+	if rOptions["timeout"] == nil {
+		t.Error("user's timeout should survive restore")
+	}
+	// User's custom model should survive.
+	rModels, _ := rAnthropic["models"].(map[string]interface{})
+	if rModels["my-custom-model"] == nil {
+		t.Error("user's custom model should survive restore")
+	}
+	// Our injected models should be removed.
+	for _, m := range databricksModels {
+		if rModels[m] != nil {
+			t.Errorf("injected model %q should be removed after restore", m)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Replaces the custom `databricks-proxy` provider with the native `anthropic` provider in OpenCode's config.json
- Injects `baseURL`, `apiKey`, and 5 Databricks Claude model entries (claude-opus-4-6, claude-opus-4-5, claude-sonnet-4-6, claude-sonnet-4-5, claude-haiku-4-5) into `provider.anthropic` while preserving all existing user config
- Surgical restore removes only injected keys on exit, leaving user's anthropic config intact
- Default model changed to `anthropic/claude-sonnet-4-6`
- Removed `OPENAI_API_KEY` env var injection (no longer needed with native provider)
- Updated README with architecture diagram, supported models table, and correct gateway URL pattern
- Updated CLAUDE.md to remove codex-specific references

Closes #5, closes #6

## Changed files

- `pkg/jsonconfig/jsonconfig.go` — Rewritten SaveOriginals/Patch/Restore for anthropic provider
- `main.go` — Default model, removed OPENAI_API_KEY env, updated help text
- `config_test.go` — Updated for anthropic provider
- `pkg/jsonconfig/jsonconfig_test.go` — Updated for anthropic provider, added preserve-existing-anthropic-config test
- `README.md` — Architecture, models, gateway URL
- `CLAUDE.md` — Removed codex references

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all tests updated for new provider)