### PR TITLE
feat: register all Databricks Claude models in provider config

### DIFF
--- a/pkg/jsonconfig/jsonconfig.go
+++ b/pkg/jsonconfig/jsonconfig.go
@@ -140,10 +140,18 @@ func (c *Config) Patch(proxyURL, modelName, apiKey string, forceModel bool) erro
 			"baseURL":   proxyURL + "/v1",
 			"authToken": apiKey,
 		},
+		// Register all available Databricks Claude models so users can switch
+		// between them in OpenCode's model picker without manual config edits.
+		// The active model is controlled by the top-level "model" key below.
+		// Register all available Databricks Claude models so users can switch
+		// between them in OpenCode's model picker without manual config edits.
+		// The active model is controlled by the top-level "model" key below.
 		"models": map[string]interface{}{
-			modelName: map[string]interface{}{
-				"name": modelName,
-			},
+			"databricks-claude-opus-4-6":   map[string]interface{}{},
+			"databricks-claude-opus-4-5":   map[string]interface{}{},
+			"databricks-claude-sonnet-4-6": map[string]interface{}{},
+			"databricks-claude-sonnet-4-5": map[string]interface{}{},
+			"databricks-claude-haiku-4-5":  map[string]interface{}{},
 		},
 	}
 	config["provider"] = providers

--- a/pkg/jsonconfig/jsonconfig_test.go
+++ b/pkg/jsonconfig/jsonconfig_test.go
@@ -67,8 +67,10 @@ func TestPatchEmptyFile(t *testing.T) {
 	if models == nil {
 		t.Fatal("databricks-proxy models not found")
 	}
-	if models["gpt-5-4"] == nil {
-		t.Error("models[\"gpt-5-4\"] not found")
+	for _, m := range []string{"databricks-claude-opus-4-6", "databricks-claude-sonnet-4-6", "databricks-claude-haiku-4-5"} {
+		if models[m] == nil {
+			t.Errorf("models[%q] not found", m)
+		}
 	}
 }
 


### PR DESCRIPTION
Adds all 5 available Databricks Claude models to the `databricks-proxy` provider config injected into `opencode.json`, so users can switch between them in OpenCode's model picker without editing config manually.

Closes #5