### PR TITLE
docs: add AGENTS.md hierarchy (deepinit)

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,26 @@
+<!-- Parent: ../../AGENTS.md -->
+
+# .github/workflows/
+
+## Purpose
+
+CI pipeline configuration for databricks-opencode.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `ci.yml` | GitHub Actions workflow: runs on pull requests to master; tests, vet, build |
+
+## Workflow: ci.yml
+
+**Trigger**: Pull requests to `master` branch
+
+**Steps**:
+1. Checkout code
+2. Setup Go from go.mod version (1.22)
+3. Run tests: `go test ./... -v`
+4. Run linter: `go vet ./...`
+5. Build binary: `go build -o databricks-opencode .`
+
+All steps must pass for PR approval.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,120 @@
+<!-- Parent: None (root) -->
+
+# databricks-opencode
+
+## Purpose
+
+A lightweight Go proxy wrapper for OpenCode CLI that routes inference requests through Databricks AI Gateway with automatic OAuth token refresh. The binary patches OpenCode's config.json, starts a local token-refreshing proxy, and launches OpenCode as a child process—so every request to the AI Gateway has a fresh, valid Databricks OAuth token without manual token management.
+
+**Architecture**: OpenCode → local proxy (OAuth injection + token refresh) → Databricks AI Gateway (/anthropic endpoint) → Anthropic
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `main.go` | Entry point: parses flags, resolves profile/model, discovers gateway URL, starts proxy, patches config, runs opencode |
+| `config.go` | ConfigManager: coordinates config.json patching, file locking, session registry, crash recovery |
+| `token.go` | Token management: databricksFetcher implements tokencache.TokenFetcher via Databricks CLI; host discovery and workspace ID resolution via SCIM |
+| `proxy.go` | ProxyConfig and proxy wrappers; wraps databricks-claude/pkg/proxy |
+| `process.go` | RunOpenCode: executes opencode as a child process with args |
+| `state.go` | loadState/saveState: persists profile and model selection to ~/.config/opencode/.state.json |
+| `lock.go` | filelock wrapper: multi-session safe config access |
+| `registry.go` | session registry wrapper: multi-session proxy handoff and crash recovery |
+| `go.mod` | Dependencies: databricks-claude v0.5.0, tidwall/jsonc v0.3.2 |
+| `Makefile` | Build targets: build, install, test, dist (cross-compile), clean, lint |
+| `README.md` | User guide: quick start, flags, architecture, installation |
+| `.github/workflows/ci.yml` | CI: runs tests, vet, build on pull requests to master |
+| `pkg/jsonconfig/jsonconfig.go` | Config patching: JSONC-aware reader/writer, managed key snapshot/restore |
+| `pkg/jsonconfig/jsonconfig_test.go` | Tests for jsonconfig |
+
+## Subdirectories
+
+| Directory | Purpose |
+|-----------|---------|
+| `pkg/jsonconfig/` | JSONC-aware OpenCode config manager (JSONC parsing, surgical patch/restore) |
+| `.github/workflows/` | CI pipeline configuration |
+
+## For AI Agents
+
+### Building and Testing
+
+```bash
+# Build the binary
+make build
+
+# Run tests
+make test
+
+# Cross-compile for all platforms
+make dist
+
+# Run linter
+make lint
+
+# Clean build artifacts
+make clean
+```
+
+### Key Patterns and Concepts
+
+1. **Profile and Model Resolution**
+   - Resolution chain for profile: `--profile` flag → `DATABRICKS_CONFIG_PROFILE` env var → saved state → "DEFAULT"
+   - Resolution chain for model: `--model` flag → saved state → "anthropic/claude-sonnet-4-6" default
+   - When flags are explicit, values are saved to `~/.config/opencode/.state.json` for future sessions
+
+2. **Token Management**
+   - TokenProvider is a wrapper around `databricks-claude/pkg/tokencache`
+   - Tokens fetched via `databricks auth token --profile <profile>` (10-second timeout)
+   - Automatic refresh with 5-minute buffer before expiry (default 55-minute expiry if not provided)
+   - Token parser handles both RFC3339 and Unix timestamp formats
+
+3. **Host and Gateway URL Discovery**
+   - Host discovered via `databricks auth env --profile <profile> --output json` → `DATABRICKS_HOST`
+   - Workspace ID resolved via SCIM `/api/2.0/preview/scim/v2/Me` endpoint, extracted from `x-databricks-org-id` header
+   - Gateway URL: `https://{workspaceId}.ai-gateway.cloud.databricks.com/anthropic` (fallback: `{host}/serving-endpoints/anthropic`)
+
+4. **Config Patching and Restoration (JSONC-Aware)**
+   - Snapshots original values of managed keys before patching (stored in `.databricks-opencode-originals.json` sidecar)
+   - Patches `~/.config/opencode/opencode.json`: sets `provider.anthropic.options.baseURL` to local proxy, `apiKey` to placeholder, injects 5 model entries
+   - On restore: surgically removes only injected keys, preserves user config
+   - Supports JSONC (JSON with comments and trailing commas) via `tidwall/jsonc`
+
+5. **Multi-Session Support and Crash Recovery**
+   - Session registry at `~/.config/opencode/.sessions.json` tracks active proxies by PID
+   - On startup: checks for sidecar/backup sentinels; if found, either hands off to surviving session or restores from crash
+   - On exit: unregisters session; if others alive, hands off config to most recent; otherwise restores fully
+   - File locking (`filelock.FileLock`) prevents concurrent config mutations
+
+6. **Proxy Startup**
+   - Proxy listens on `127.0.0.1:0` (random available port)
+   - Port discovered from listener.Addr(), passed to config as `baseURL`
+   - Supports HTTP (default) and HTTPS (with `--tls-cert` and `--tls-key`)
+   - No OTEL upstream needed for OpenCode (inference-only)
+
+7. **OpenCode Launch and Cleanup**
+   - Patches config, starts proxy, launches opencode as child with user-provided args
+   - **Critical**: restores config.json explicitly before `os.Exit()` (not deferred, since `os.Exit()` skips defers)
+   - Crash recovery: sidecar file survives process death and guides restoration on next run
+
+8. **Flag Parsing**
+   - Databricks-opencode flags: `--profile`, `--model`, `--upstream`, `--log-file`, `--verbose`, `--version`, `--help`, `--print-env`, `--proxy-api-key`, `--tls-cert`, `--tls-key`
+   - Separator: `--` passes remaining args to opencode (e.g., `databricks-opencode -- --chat`)
+   - Flags not recognized as databricks-opencode flags are passed through to opencode
+
+### Important Notes for Development
+
+- **Token expiry conservative default**: 55 minutes (vs. typical 60) to build safety margin
+- **Timeout on token fetch and host discovery**: 10 seconds; context-aware
+- **Security warnings**: `proxy.SecurityChecks()` emitted to stderr on startup (e.g., binding to localhost only)
+- **Logging**: disabled by default (io.Discard); `--verbose` sends logs to stderr; `--log-file` writes to file (combinable)
+- **Config backup sentinel**: empty file at `~/.config/opencode/opencode.json.databricks-opencode-backup` for crash detection (no full copy)
+- **Sidecar format**: JSON with boolean flags for "absent" markers (to distinguish "key was absent" from "key was empty string")
+- **Atomic writes**: config changes use temp file + rename for crash safety
+
+## Dependencies
+
+| Dependency | Version | Purpose |
+|------------|---------|---------|
+| `github.com/IceRhymers/databricks-claude` | v0.5.0 | Core packages: `pkg/proxy` (HTTP proxy with token injection), `pkg/tokencache` (token caching), `pkg/authcheck` (auth validation), `pkg/childproc` (child process helpers), `pkg/filelock` (file-based locking), `pkg/registry` (session registry) |
+| `github.com/tidwall/jsonc` | v0.3.2 | JSONC parsing: strips comments and trailing commas from JSON5-like config |
+| Go stdlib | 1.22+ | `net/http`, `os`, `log`, `context`, `json`, `filepath`, `io` |

--- a/pkg/AGENTS.md
+++ b/pkg/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- Parent: ../AGENTS.md -->
+
+# pkg/
+
+## Purpose
+
+Local packages extending the shared databricks-claude library. Currently contains `jsonconfig/`, which provides JSONC-aware (JSON with comments) config management for OpenCode's config.json file.
+
+See parent AGENTS.md for overall project context and build/test instructions.

--- a/pkg/jsonconfig/AGENTS.md
+++ b/pkg/jsonconfig/AGENTS.md
@@ -1,0 +1,176 @@
+<!-- Parent: ../AGENTS.md -->
+
+# pkg/jsonconfig
+
+## Purpose
+
+JSONC-aware OpenCode config manager. Reads, patches, and restores `~/.config/opencode/opencode.json`, supporting JSON with comments and trailing commas. Implements surgical patching (injects only necessary keys) and crash-safe restoration via sidecar file snapshots.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `jsonconfig.go` | Config type and methods: readConfig (JSONC stripping), Patch (inject proxy settings), Restore (surgical removal), SaveOriginals/loadSidecar (crash recovery) |
+| `jsonconfig_test.go` | Comprehensive tests: JSONC parsing, patch/restore, sentinel handling, key tracking |
+
+## Core Concepts
+
+### Managed Keys
+
+The config manager tracks and patches these keys:
+- `model` — active model identifier (set only if --model explicit or absent)
+- `provider.anthropic.options.baseURL` — proxy address
+- `provider.anthropic.options.apiKey` — placeholder key
+- `provider.anthropic.models[claude-opus-4-6|claude-opus-4-5|claude-sonnet-4-6|claude-sonnet-4-5|claude-haiku-4-5]` — model entries
+
+### Surgical Patching
+
+- Snapshots original values before patching via `SaveOriginals()` (writes `.databricks-opencode-originals.json` sidecar)
+- Distinguishes "key was absent" from "key had empty value" using sentinel marker
+- On restore: only removes keys that were absent before; preserves user's existing keys
+- Example: if user had `provider.anthropic.options.timeout: 30`, it's left alone; only injected keys removed
+
+### JSONC Support
+
+```go
+// Strips comments and trailing commas before JSON parsing
+clean := jsonc.ToJSON(data)
+```
+
+Allows users to write:
+```jsonc
+{
+  // OpenCode configuration
+  "model": "my-model",  // with trailing comma
+  "provider": { ... }
+}
+```
+
+### Crash Recovery
+
+1. **Sentinel**: `WriteSentinel()` creates empty backup file `opencode.json.databricks-opencode-backup` on startup
+2. **Sidecar**: `SaveOriginals()` writes `.databricks-opencode-originals.json` with original values
+3. **Detection**: On next startup, presence of sidecar indicates crash
+4. **Action**: Restore from sidecar or hand off to surviving session
+
+**Sidecar schema** (JSON):
+```json
+{
+  "model": "original-value",
+  "model_absent": false,
+  "anthropic_options_baseURL": "original-url",
+  "anthropic_options_baseURL_absent": false,
+  "anthropic_options_apiKey": "original-key",
+  "anthropic_options_apiKey_absent": true,
+  "existing_models": {"claude-sonnet-4-6": true}
+}
+```
+
+### Atomic Writes
+
+```go
+// 1. Create temp file in same directory
+tmp, _ := os.CreateTemp(dir, ".config-*.tmp")
+// 2. Set restrictive permissions (0o600)
+os.Chmod(tmpPath, 0o600)
+// 3. Write data
+tmp.Write(data)
+tmp.Close()
+// 4. Atomic rename
+os.Rename(tmpPath, path)
+```
+
+Ensures config is never in a half-written state.
+
+## Methods
+
+### Config Lifecycle
+
+| Method | Purpose |
+|--------|---------|
+| `New()` | Create Config for `~/.config/opencode/opencode.json` |
+| `NewWithPath(configPath, backupPath)` | Create with explicit paths (testing) |
+| `Path() / BackupPath() / SidecarPath()` | Get file paths |
+| `HasBackup() / HasSidecar()` | Check for sentinel/sidecar files |
+
+### Patching and Restoration
+
+| Method | Purpose |
+|--------|---------|
+| `SaveOriginals()` | Snapshot managed keys and write sidecar |
+| `Patch(proxyURL, modelName, apiKey, forceModel)` | Inject proxy config; set model only if forceModel or absent |
+| `Restore()` | Surgically remove only our injected keys; restore originals |
+| `UpdateProxyURL(proxyURL)` | Change baseURL only (multi-session handoff) |
+
+### Sentinel Management
+
+| Method | Purpose |
+|--------|---------|
+| `WriteSentinel()` | Create empty backup file for crash detection |
+| `RemoveSentinel()` | Delete sentinel |
+| `Backup()` | Alias to WriteSentinel (for backward compat) |
+
+### Internal Helpers
+
+| Method | Purpose |
+|--------|---------|
+| `readConfig()` | Read, JSONC-strip, parse JSON; return empty map if missing |
+| `writeConfig(config)` | Marshal and atomically write config |
+| `writeSidecar() / loadSidecar()` | Persist/load originals for crash recovery |
+| `cleanup()` | Remove sidecar and sentinel files |
+| `getMap(parent, key)` | Safe nested map extraction |
+| `atomicWrite(path, data)` | Temp file + rename |
+
+## For AI Agents
+
+### Testing the Config Manager
+
+```bash
+cd /tmp/databricks-opencode
+make test
+```
+
+Key test scenarios in `jsonconfig_test.go`:
+- JSONC parsing (comments, trailing commas)
+- Patch with forceModel true/false
+- Restore: verify only injected keys removed
+- Sentinel/sidecar creation and detection
+- Crash recovery: restore from sidecar
+- Multi-session: UpdateProxyURL handoff
+- Empty config, missing keys, user config preservation
+
+### Common Patterns
+
+1. **Setting up a session**:
+   ```go
+   config := jsonconfig.New()
+   config.SaveOriginals()
+   config.WriteSentinel()
+   config.Patch(proxyURL, modelName, apiKey, forceModel)
+   ```
+
+2. **Restoring after exit**:
+   ```go
+   config.Restore()  // Surgical remove + cleanup
+   ```
+
+3. **Handing off to another session**:
+   ```go
+   config.UpdateProxyURL(anotherProxyURL)
+   // Leave sidecar intact for that session's eventual restore
+   ```
+
+### Important Notes
+
+- **forceModel parameter**: if true, `model` is always written; if false, only set if absent (preserve user choice)
+- **Absent sentinel**: the `absent` struct{} distinguishes "never had a value" from "had empty string"
+- **JSONC limitations**: only strips comments and trailing commas; doesn't validate JSON5 features like unquoted keys or single quotes
+- **Permissions**: sidecar and temp files written with 0o600 (user read/write only)
+- **Crash recovery in config.go**: ConfigManager handles sidecar detection; jsonconfig only provides I/O primitives
+
+## Dependencies
+
+| Dependency | Purpose |
+|------------|---------|
+| `github.com/tidwall/jsonc` | JSONC parsing (strip comments/trailing commas) |
+| Go stdlib | `encoding/json`, `os`, `filepath` |


### PR DESCRIPTION
Adds hierarchical AGENTS.md documentation across the repo via deepinit.

- Root AGENTS.md — project overview, key files, build/test commands, patterns
- pkg/AGENTS.md — local packages description
- pkg/jsonconfig/AGENTS.md — detailed JSONC config manager docs
- .github/workflows/AGENTS.md — CI workflow docs

Supersedes #8