### PR TITLE
fix: concurrent session proxy takeover on owner death

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,14 +3,18 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"log"
+	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/IceRhymers/databricks-claude/pkg/authcheck"
 	"github.com/IceRhymers/databricks-claude/pkg/portbind"
@@ -172,16 +176,18 @@ func main() {
 		log.Fatalf("databricks-opencode: failed to bind port %d: %v", port, err)
 	}
 
+	// --- Build proxy handler (needed by both owner and watchdog) ---
+	proxyHandler := NewProxyServer(&ProxyConfig{
+		InferenceUpstream: gatewayURL,
+		TokenProvider:     tp,
+		Verbose:           verbose,
+		APIKey:            proxyAPIKey,
+		TLSCertFile:       tlsCert,
+		TLSKeyFile:        tlsKey,
+	})
+
 	// --- If we own the listener, start the proxy on it ---
 	if isOwner {
-		proxyHandler := NewProxyServer(&ProxyConfig{
-			InferenceUpstream: gatewayURL,
-			TokenProvider:     tp,
-			Verbose:           verbose,
-			APIKey:            proxyAPIKey,
-			TLSCertFile:       tlsCert,
-			TLSKeyFile:        tlsKey,
-		})
 		servedLn, err := proxy.Serve(listener, proxyHandler, tlsCert, tlsKey)
 		if err != nil {
 			log.Fatalf("databricks-opencode: failed to start proxy: %v", err)
@@ -190,13 +196,15 @@ func main() {
 		log.Printf("databricks-opencode: proxy owner on :%d", port)
 	} else {
 		log.Printf("databricks-opencode: joining existing proxy on :%d", port)
+		// Watch for owner death and take over the proxy if needed.
+		go watchProxy(port, proxyHandler, tlsCert, tlsKey)
 	}
 
-	proxyScheme := "http://"
+	proxyScheme := "http"
 	if tlsCert != "" && tlsKey != "" {
-		proxyScheme = "https://"
+		proxyScheme = "https"
 	}
-	proxyAddr := proxyScheme + listener.Addr().String()
+	proxyAddr := fmt.Sprintf("%s://127.0.0.1:%d", proxyScheme, listenerPort(listener, port))
 	log.Printf("databricks-opencode: local proxy %s -> %s", proxyAddr, gatewayURL)
 
 	// --- Acquire refcount ---
@@ -406,6 +414,63 @@ OpenCode CLI Options:
 	cmd.Stderr = &buf
 	_ = cmd.Run()
 	fmt.Print(buf.String())
+}
+
+// proxyHealthy checks whether the proxy on the given port is responding.
+func proxyHealthy(port int, scheme string) bool {
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	if scheme == "https" {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+	}
+	resp, err := client.Get(fmt.Sprintf("%s://127.0.0.1:%d/health", scheme, port))
+	if err != nil {
+		return false
+	}
+	resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// watchProxy polls the proxy health endpoint and takes over the port if the
+// owner process dies. Runs as a goroutine for non-owner sessions.
+func watchProxy(port int, handler http.Handler, tlsCert, tlsKey string) {
+	scheme := "http"
+	if tlsCert != "" && tlsKey != "" {
+		scheme = "https"
+	}
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		if proxyHealthy(port, scheme) {
+			continue
+		}
+
+		// Proxy is unreachable — try to bind the port and take over.
+		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			continue // another session grabbed it first
+		}
+		if _, err := proxy.Serve(ln, handler, tlsCert, tlsKey); err != nil {
+			ln.Close()
+			continue
+		}
+		log.Printf("databricks-opencode: proxy owner died, took over on :%d", port)
+		return
+	}
+}
+
+// listenerPort returns the port from the listener, or fallback if ln is nil.
+func listenerPort(ln net.Listener, fallback int) int {
+	if ln == nil {
+		return fallback
+	}
+	if addr, ok := ln.Addr().(*net.TCPAddr); ok {
+		return addr.Port
+	}
+	return fallback
 }
 
 // handlePrintEnv prints resolved configuration with the token redacted.


### PR DESCRIPTION
## Summary
- **Fixed nil pointer crash** when a second session joined an existing proxy — `portbind.Bind` returns a nil listener for non-owners, and `listener.Addr().String()` panicked at main.go:199
- **Added proxy takeover** via a `watchProxy` goroutine that polls `/health` every 2s and rebinds the port if the owner process dies, so surviving sessions recover within ~2 seconds
- Moved proxy handler creation before the `isOwner` branch so the watchdog can reuse it

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all existing tests green)
- [ ] Manual: start two sessions, kill the first (owner) — second session should log "proxy owner died, took over" and continue serving API requests
- [ ] Manual: start two sessions, kill the second (non-owner) — owner proxy unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)