### PR TITLE
feat: --headless mode for proxy-only startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,9 +11,11 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/IceRhymers/databricks-claude/pkg/authcheck"
@@ -27,7 +29,7 @@ import (
 var Version = "dev"
 
 func main() {
-	verbose, version, showHelp, printEnv, model, upstream, logFile, profile, proxyAPIKey, tlsCert, tlsKey, portFlag, opencodeArgs := parseArgs(os.Args[1:])
+	verbose, version, showHelp, printEnv, model, upstream, logFile, profile, proxyAPIKey, tlsCert, tlsKey, portFlag, headless, opencodeArgs := parseArgs(os.Args[1:])
 
 	if showHelp {
 		handleHelp(upstream)
@@ -165,9 +167,11 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Verify opencode is on PATH before starting proxy.
-	if _, err := exec.LookPath("opencode"); err != nil {
-		log.Fatalf("databricks-opencode: opencode binary not found on PATH — install from https://opencode.ai")
+	// Verify opencode is on PATH before starting proxy (skip in headless mode).
+	if !headless {
+		if _, err := exec.LookPath("opencode"); err != nil {
+			log.Fatalf("databricks-opencode: opencode binary not found on PATH — install from https://opencode.ai")
+		}
 	}
 
 	// --- Bind to fixed port (or health-check existing owner) ---
@@ -215,7 +219,17 @@ func main() {
 
 	// --- Ensure config.json points at the local proxy (idempotent) ---
 	if err := EnsureConfig(jsonconfig.New(), proxyAddr, model, proxyAPIKey, modelExplicit); err != nil {
-		log.Fatalf("databricks-opencode: failed to configure opencode: %v", err)
+		if headless {
+			log.Printf("databricks-opencode: WARNING: failed to configure opencode: %v", err)
+		} else {
+			log.Fatalf("databricks-opencode: failed to configure opencode: %v", err)
+		}
+	}
+
+	// --- Headless mode: print proxy URL and block until signal ---
+	if headless {
+		runHeadless(proxyAddr, listener, isOwner, refcountPath)
+		return
 	}
 
 	// Set OPENAI_API_KEY as a placeholder — the proxy overwrites the
@@ -244,7 +258,7 @@ func main() {
 }
 
 // parseArgs separates databricks-opencode flags from opencode flags.
-func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printEnv bool, model string, upstream string, logFile string, profile string, proxyAPIKey string, tlsCert string, tlsKey string, port int, opencodeArgs []string) {
+func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printEnv bool, model string, upstream string, logFile string, profile string, proxyAPIKey string, tlsCert string, tlsKey string, port int, headless bool, opencodeArgs []string) {
 	knownFlags := map[string]bool{
 		"--verbose":       true,
 		"--version":       true,
@@ -258,6 +272,7 @@ func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printE
 		"--tls-cert":      true,
 		"--tls-key":       true,
 		"--port":          true,
+		"--headless":      true,
 	}
 
 	i := 0
@@ -355,6 +370,8 @@ func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printE
 					showHelp = true
 				case "--print-env":
 					printEnv = true
+				case "--headless":
+					headless = true
 				}
 				i++
 				continue
@@ -366,6 +383,20 @@ func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printE
 		i++
 	}
 	return
+}
+
+// runHeadless starts the proxy without launching the opencode child process.
+// It prints the proxy URL to stdout and blocks until SIGINT or SIGTERM.
+func runHeadless(proxyURL string, ln net.Listener, isOwner bool, refcountPath string) {
+	fmt.Printf("PROXY_URL=%s\n", proxyURL)
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	<-sigCh
+	signal.Stop(sigCh)
+	n, _ := refcount.Release(refcountPath)
+	if n == 0 && isOwner {
+		ln.Close()
+	}
 }
 
 // handleHelp prints the databricks-opencode help section, then execs opencode --help.
@@ -389,6 +420,7 @@ Databricks-OpenCode Flags:
   --tls-cert string         Path to TLS certificate file (requires --tls-key)
   --tls-key string          Path to TLS private key file (requires --tls-cert)
   --port int                Local proxy port (default: 49155, saved for future sessions)
+  --headless            Start proxy without launching opencode (for IDE extensions)
   --version             Print version and exit
   --help, -h            Show this help message
 

--- a/main_test.go
+++ b/main_test.go
@@ -14,7 +14,7 @@ import (
 // --- parseArgs tests ---
 
 func TestParseArgs_HelpLong(t *testing.T) {
-	verbose, version, showHelp, printEnv, model, upstream, logFile, profile, _, _, _, _, opencodeArgs := parseArgs([]string{"--help"})
+	verbose, version, showHelp, printEnv, model, upstream, logFile, profile, _, _, _, _, _, opencodeArgs := parseArgs([]string{"--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true for --help")
 	}
@@ -24,91 +24,91 @@ func TestParseArgs_HelpLong(t *testing.T) {
 }
 
 func TestParseArgs_HelpShort(t *testing.T) {
-	_, _, showHelp, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
+	_, _, showHelp, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
 	if !showHelp {
 		t.Error("expected showHelp=true for -h")
 	}
 }
 
 func TestParseArgs_PrintEnv(t *testing.T) {
-	_, _, _, printEnv, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
+	_, _, _, printEnv, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
 	if !printEnv {
 		t.Error("expected printEnv=true for --print-env")
 	}
 }
 
 func TestParseArgs_Version(t *testing.T) {
-	_, version, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
+	_, version, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
 	if !version {
 		t.Error("expected version=true for --version")
 	}
 }
 
 func TestParseArgs_Verbose(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
 	if !verbose {
 		t.Error("expected verbose=true for --verbose")
 	}
 }
 
 func TestParseArgs_VerboseShort(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
 	if !verbose {
 		t.Error("expected verbose=true for -v")
 	}
 }
 
 func TestParseArgs_LogFile(t *testing.T) {
-	_, _, _, _, _, _, logFile, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
+	_, _, _, _, _, _, logFile, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_LogFileEquals(t *testing.T) {
-	_, _, _, _, _, _, logFile, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
+	_, _, _, _, _, _, logFile, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_Upstream(t *testing.T) {
-	_, _, _, _, _, upstream, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "https://gw.example.com/openai/v1"})
+	_, _, _, _, _, upstream, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "https://gw.example.com/openai/v1"})
 	if upstream != "https://gw.example.com/openai/v1" {
 		t.Errorf("expected upstream=%q, got %q", "https://gw.example.com/openai/v1", upstream)
 	}
 }
 
 func TestParseArgs_UpstreamEquals(t *testing.T) {
-	_, _, _, _, _, upstream, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream=https://gw.example.com/openai/v1"})
+	_, _, _, _, _, upstream, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream=https://gw.example.com/openai/v1"})
 	if upstream != "https://gw.example.com/openai/v1" {
 		t.Errorf("expected upstream=%q, got %q", "https://gw.example.com/openai/v1", upstream)
 	}
 }
 
 func TestParseArgs_Model(t *testing.T) {
-	_, _, _, _, model, _, _, _, _, _, _, _, _ := parseArgs([]string{"--model", "gpt-4o"})
+	_, _, _, _, model, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--model", "gpt-4o"})
 	if model != "gpt-4o" {
 		t.Errorf("expected model=%q, got %q", "gpt-4o", model)
 	}
 }
 
 func TestParseArgs_ModelEquals(t *testing.T) {
-	_, _, _, _, model, _, _, _, _, _, _, _, _ := parseArgs([]string{"--model=gpt-4o"})
+	_, _, _, _, model, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--model=gpt-4o"})
 	if model != "gpt-4o" {
 		t.Errorf("expected model=%q, got %q", "gpt-4o", model)
 	}
 }
 
 func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{"--unknown"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{"--unknown"})
 	if len(opencodeArgs) != 1 || opencodeArgs[0] != "--unknown" {
 		t.Errorf("expected opencodeArgs=[\"--unknown\"], got %v", opencodeArgs)
 	}
 }
 
 func TestParseArgs_EmptyArgs(t *testing.T) {
-	verbose, version, showHelp, printEnv, model, upstream, logFile, profile, _, _, _, _, opencodeArgs := parseArgs([]string{})
+	verbose, version, showHelp, printEnv, model, upstream, logFile, profile, _, _, _, _, _, opencodeArgs := parseArgs([]string{})
 	if verbose || version || showHelp || printEnv {
 		t.Error("expected all bool flags false for empty args")
 	}
@@ -130,7 +130,7 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 }
 
 func TestParseArgs_Mixed(t *testing.T) {
-	verbose, _, showHelp, _, _, upstream, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose", "--upstream", "https://gw.example.com", "--help"})
+	verbose, _, showHelp, _, _, upstream, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose", "--upstream", "https://gw.example.com", "--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true")
 	}
@@ -143,7 +143,7 @@ func TestParseArgs_Mixed(t *testing.T) {
 }
 
 func TestParseArgs_Separator(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{"--verbose", "--", "--unknown", "arg1"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{"--verbose", "--", "--unknown", "arg1"})
 	if !verbose {
 		t.Error("expected verbose=true before separator")
 	}
@@ -153,7 +153,7 @@ func TestParseArgs_Separator(t *testing.T) {
 }
 
 func TestParseArgs_PassthroughArgs(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{"prompt text", "--some-flag", "value"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{"prompt text", "--some-flag", "value"})
 	if len(opencodeArgs) != 3 {
 		t.Errorf("expected 3 opencodeArgs, got %d: %v", len(opencodeArgs), opencodeArgs)
 	}
@@ -257,7 +257,7 @@ func TestParseArgs_Table(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			verbose, version, showHelp, printEnv, model, upstream, logFile, profile, _, _, _, _, opencodeArgs := parseArgs(tc.args)
+			verbose, version, showHelp, printEnv, model, upstream, logFile, profile, _, _, _, _, _, opencodeArgs := parseArgs(tc.args)
 
 			if verbose != tc.want.verbose {
 				t.Errorf("verbose: got %v, want %v", verbose, tc.want.verbose)
@@ -415,14 +415,14 @@ func TestHandleHelp_ContainsOpenCodeCLISeparator(t *testing.T) {
 }
 
 func TestParseArgs_Profile(t *testing.T) {
-	_, _, _, _, _, _, _, profile, _, _, _, _, _ := parseArgs([]string{"--profile", "aidev"})
+	_, _, _, _, _, _, _, profile, _, _, _, _, _, _ := parseArgs([]string{"--profile", "aidev"})
 	if profile != "aidev" {
 		t.Errorf("expected profile=%q, got %q", "aidev", profile)
 	}
 }
 
 func TestParseArgs_ProfileEquals(t *testing.T) {
-	_, _, _, _, _, _, _, profile, _, _, _, _, _ := parseArgs([]string{"--profile=production"})
+	_, _, _, _, _, _, _, profile, _, _, _, _, _, _ := parseArgs([]string{"--profile=production"})
 	if profile != "production" {
 		t.Errorf("expected profile=%q, got %q", "production", profile)
 	}
@@ -508,16 +508,30 @@ func TestProfileResolution_DefaultWhenNoStateFile(t *testing.T) {
 }
 
 func TestParseArgs_Port(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, port, _ := parseArgs([]string{"--port", "8080"})
+	_, _, _, _, _, _, _, _, _, _, _, port, _, _ := parseArgs([]string{"--port", "8080"})
 	if port != 8080 {
 		t.Errorf("expected port=8080, got %d", port)
 	}
 }
 
 func TestParseArgs_PortEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, port, _ := parseArgs([]string{"--port=9000"})
+	_, _, _, _, _, _, _, _, _, _, _, port, _, _ := parseArgs([]string{"--port=9000"})
 	if port != 9000 {
 		t.Errorf("expected port=9000, got %d", port)
+	}
+}
+
+func TestParseArgs_Headless(t *testing.T) {
+	_, _, _, _, _, _, _, _, _, _, _, _, headless, _ := parseArgs([]string{"--headless"})
+	if !headless {
+		t.Error("expected headless=true for --headless")
+	}
+}
+
+func TestParseArgs_HeadlessDefault(t *testing.T) {
+	_, _, _, _, _, _, _, _, _, _, _, _, headless, _ := parseArgs([]string{})
+	if headless {
+		t.Error("expected headless=false for empty args")
 	}
 }
 
@@ -525,7 +539,7 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp("")
 	})
-	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--model", "--version", "--help", "--port"}
+	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--model", "--version", "--help", "--port", "--headless"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
 			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)


### PR DESCRIPTION
## Summary

Adds a `--headless` flag that starts the proxy without launching the `opencode` child process. Intended for VS Code/JetBrains extensions that want a long-running proxy.

• Prints `PROXY_URL=<url>` to stdout and blocks on SIGINT/SIGTERM
• EnsureConfig errors become warnings (non-fatal) in headless mode
• Skips the `opencode` binary LookPath check when headless
• Added to help text, parseArgs, and new tests

Closes #21

## Changes

• `main.go` — added `headless` to `parseArgs` return values, `--headless` flag parsing, `runHeadless()` function, headless branch in `main()`, help text entry
• `main_test.go` — updated all `parseArgs` call sites for new return value, added `TestParseArgs_Headless` and `TestParseArgs_HeadlessDefault`

## Test plan

• `go build ./...` passes
• `go test ./...` passes (all existing + 2 new tests)
• Manual: `databricks-opencode --headless` prints `PROXY_URL=...` and blocks until Ctrl-C