### PR TITLE
chore: bump databricks-claude to v0.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/IceRhymers/databricks-opencode
 go 1.22
 
 require (
-	github.com/IceRhymers/databricks-claude v0.6.0
+	github.com/IceRhymers/databricks-claude v0.8.1
 	github.com/tidwall/jsonc v0.3.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/IceRhymers/databricks-claude v0.6.0 h1:0dA07ibYTqbw0FgYkmLPHuAalRAeVajHOTdVLreyLYc=
-github.com/IceRhymers/databricks-claude v0.6.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
+github.com/IceRhymers/databricks-claude v0.8.1 h1:1gFFG98yLNWf8cR+aFrHIrrTMFItQ/AvRUaPdcnngVU=
+github.com/IceRhymers/databricks-claude v0.8.1/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
 github.com/tidwall/jsonc v0.3.2 h1:ZTKrmejRlAJYdn0kcaFqRAKlxxFIC21pYq8vLa4p2Wc=
 github.com/tidwall/jsonc v0.3.2/go.mod h1:dw+3CIxqHi+t8eFSpzzMlcVYxKp08UP5CD8/uSFCyJE=


### PR DESCRIPTION
Picks up the Windows cross-compilation fix (platform-specific `pkg/refcount` and `pkg/proxy/checks`) so `GOOS=windows` builds succeed in CI.