### PR TITLE
fix: retrigger homebrew dispatch for v0.2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,4 @@ No shell alias needed — `databricks-opencode` is a standalone binary.
 ## License
 
 MIT — see [LICENSE](LICENSE).
+


### PR DESCRIPTION
Triggers release-please to cut v0.2.1 so the homebrew-tap dispatch fires.