### PR TITLE
feat: add update subcommand and startup update check

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,50 @@ If installed via `brew install IceRhymers/tap/databricks-opencode`, completions 
 - `--upstream`, `--log-file`, `--tls-cert`, `--tls-key <TAB>` — file path completion
 - All other flags — name completion when you type `-`
 
+## Automatic Update Check
+
+`databricks-opencode` checks for newer releases on startup (once every 24 hours) and prints a one-line notice to stderr when an update is available. The check is synchronous with a 2-second timeout — if GitHub is unreachable it silently skips.
+
+### Update notification
+
+When a newer version exists you'll see:
+
+```
+# Direct install
+databricks-opencode: update available (v0.8.0). Run: databricks-opencode update
+
+# Homebrew install
+databricks-opencode: update available (v0.8.0). Run: brew upgrade databricks-opencode
+```
+
+### `update` subcommand
+
+```bash
+databricks-opencode update
+```
+
+Force-checks GitHub for the latest release (bypasses the 24-hour cache) and prints upgrade instructions:
+
+| Install method | Output |
+|---|---|
+| Already latest | `databricks-opencode v0.7.1 is already the latest version` |
+| Direct install | `Update available: v0.8.0. Download from: https://github.com/...` |
+| Homebrew | `Update available: v0.8.0. Run: brew upgrade databricks-opencode` |
+
+No binary is replaced — the command prints instructions only. In-place self-update is planned for a future release.
+
+### Opt out
+
+```bash
+# Per-invocation flag
+databricks-opencode --no-update-check
+
+# Per-session or permanent (add to shell profile)
+export DATABRICKS_NO_UPDATE_CHECK=1
+```
+
+Both suppress the startup check and disable the `update` subcommand.
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -29,6 +29,7 @@ var flagDefs = []completion.FlagDef{
 	{Name: "install-hooks", Description: "Install opencode plugin for automatic proxy lifecycle"},
 	{Name: "uninstall-hooks", Description: "Remove databricks-opencode plugin from opencode"},
 	{Name: "headless-ensure", Description: "Ensure headless proxy is running (called by opencode plugin)"},
+	{Name: "no-update-check", Description: "Skip the automatic update check on startup"},
 }
 
 // knownFlags is the set of flag names (with "--" prefix) that databricks-opencode

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/IceRhymers/databricks-opencode
 go 1.22
 
 require (
-	github.com/IceRhymers/databricks-claude v0.10.1
+	github.com/IceRhymers/databricks-claude v0.11.0
 	github.com/tidwall/jsonc v0.3.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/IceRhymers/databricks-claude v0.10.1 h1:jg7KK6UfjQyGm2wG+byu11UOdtyrlp8oWnrkbgCaLzo=
-github.com/IceRhymers/databricks-claude v0.10.1/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
+github.com/IceRhymers/databricks-claude v0.11.0 h1:VjR+gSPYDINk7DJEI4kR9UP6mRIoyzPoB1wsy7DJBn4=
+github.com/IceRhymers/databricks-claude v0.11.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
 github.com/tidwall/jsonc v0.3.2 h1:ZTKrmejRlAJYdn0kcaFqRAKlxxFIC21pYq8vLa4p2Wc=
 github.com/tidwall/jsonc v0.3.2/go.mod h1:dw+3CIxqHi+t8eFSpzzMlcVYxKp08UP5CD8/uSFCyJE=

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"os/signal"
 	"strconv"
 	"strings"
@@ -24,6 +25,7 @@ import (
 	"github.com/IceRhymers/databricks-claude/pkg/portbind"
 	"github.com/IceRhymers/databricks-claude/pkg/proxy"
 	"github.com/IceRhymers/databricks-claude/pkg/refcount"
+	"github.com/IceRhymers/databricks-claude/pkg/updater"
 	"github.com/IceRhymers/databricks-opencode/pkg/jsonconfig"
 )
 
@@ -38,7 +40,34 @@ func main() {
 		os.Exit(0)
 	}
 
-	verbose, version, showHelp, printEnv, model, upstream, logFile, profile, proxyAPIKey, tlsCert, tlsKey, portFlag, headless, idleTimeout, installHooksFlag, uninstallHooksFlag, headlessEnsureFlag, opencodeArgs := parseArgs(os.Args[1:])
+	// update — force-check for a newer release and print instructions.
+	if len(os.Args) >= 2 && os.Args[1] == "update" {
+		if os.Getenv("DATABRICKS_NO_UPDATE_CHECK") == "1" {
+			fmt.Fprintln(os.Stderr, "databricks-opencode: update check disabled via DATABRICKS_NO_UPDATE_CHECK")
+			os.Exit(0)
+		}
+		cfg := buildUpdaterConfig()
+		cfg.CacheTTL = 0 // force fresh check
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		r, err := updater.Check(ctx, cfg)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "databricks-opencode: update check failed: %v\n", err)
+			os.Exit(1)
+		}
+		if !r.UpdateAvailable {
+			fmt.Fprintf(os.Stderr, "databricks-opencode v%s is already the latest version\n", Version)
+			os.Exit(0)
+		}
+		if r.IsHomebrew {
+			fmt.Fprintf(os.Stderr, "Update available: v%s. Run: brew upgrade databricks-opencode\n", r.LatestVersion)
+		} else {
+			fmt.Fprintf(os.Stderr, "Update available: v%s. Download from: %s\n", r.LatestVersion, r.ReleaseURL)
+		}
+		os.Exit(0)
+	}
+
+	verbose, version, showHelp, printEnv, model, upstream, logFile, profile, proxyAPIKey, tlsCert, tlsKey, portFlag, headless, idleTimeout, installHooksFlag, uninstallHooksFlag, headlessEnsureFlag, noUpdateCheck, opencodeArgs := parseArgs(os.Args[1:])
 
 	if showHelp {
 		handleHelp(upstream)
@@ -284,6 +313,11 @@ func main() {
 		return
 	}
 
+	// --- Synchronous update check (before child to avoid stderr interleaving) ---
+	if !noUpdateCheck && os.Getenv("DATABRICKS_NO_UPDATE_CHECK") != "1" {
+		printUpdateNotice(buildUpdaterConfig())
+	}
+
 	log.Printf("databricks-opencode: launching opencode")
 
 	// Inject MANAGED env var so the child opencode session's hooks don't
@@ -310,7 +344,7 @@ func main() {
 }
 
 // parseArgs separates databricks-opencode flags from opencode flags.
-func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printEnv bool, model string, upstream string, logFile string, profile string, proxyAPIKey string, tlsCert string, tlsKey string, port int, headless bool, idleTimeout time.Duration, installHooksFlag bool, uninstallHooksFlag bool, headlessEnsureFlag bool, opencodeArgs []string) {
+func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printEnv bool, model string, upstream string, logFile string, profile string, proxyAPIKey string, tlsCert string, tlsKey string, port int, headless bool, idleTimeout time.Duration, installHooksFlag bool, uninstallHooksFlag bool, headlessEnsureFlag bool, noUpdateCheck bool, opencodeArgs []string) {
 	idleTimeout = 30 * time.Minute // default
 
 	// knownFlags is defined at package level in completion_flags.go,
@@ -432,6 +466,8 @@ func parseArgs(args []string) (verbose bool, version bool, showHelp bool, printE
 					uninstallHooksFlag = true
 				case "--headless-ensure":
 					headlessEnsureFlag = true
+				case "--no-update-check":
+					noUpdateCheck = true
 				}
 				i++
 				continue
@@ -492,8 +528,13 @@ Databricks-OpenCode Flags:
   --install-hooks       Install opencode plugin hooks for automatic proxy lifecycle
   --uninstall-hooks     Remove databricks-opencode plugin from opencode config
   --headless-ensure     Start proxy if not running (called by opencode plugin at init)
+  --no-update-check            Skip the automatic update check on startup
   --version             Print version and exit
   --help, -h            Show this help message
+
+Subcommands:
+  completion <shell>           Generate shell completions (bash, zsh, fish)
+  update                       Check for a newer release and print upgrade instructions
 
 ────────────────────────────────────────────────────────────────────────────────
 OpenCode CLI Options:
@@ -574,6 +615,38 @@ func listenerPort(ln net.Listener, fallback int) int {
 		return addr.Port
 	}
 	return fallback
+}
+
+// buildUpdaterConfig returns the standard updater.Config for databricks-opencode.
+func buildUpdaterConfig() updater.Config {
+	home, _ := os.UserHomeDir()
+	return updater.Config{
+		RepoSlug:       "IceRhymers/databricks-opencode",
+		CurrentVersion: Version,
+		BinaryName:     "databricks-opencode",
+		CacheFile:      filepath.Join(home, ".config", "opencode", ".update-check.json"),
+		CacheTTL:       24 * time.Hour,
+	}
+}
+
+// printUpdateNotice checks for a newer release and prints a one-line notice
+// to stderr. The 2-second timeout ensures cold misses don't delay startup.
+func printUpdateNotice(cfg updater.Config) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	r, err := updater.Check(ctx, cfg)
+	if err != nil {
+		log.Printf("databricks-opencode: update check: %v", err)
+		return
+	}
+	if !r.UpdateAvailable {
+		return
+	}
+	if r.IsHomebrew {
+		fmt.Fprintf(os.Stderr, "databricks-opencode: update available (v%s). Run: brew upgrade databricks-opencode\n", r.LatestVersion)
+	} else {
+		fmt.Fprintf(os.Stderr, "databricks-opencode: update available (v%s). Run: databricks-opencode update\n", r.LatestVersion)
+	}
 }
 
 // handlePrintEnv prints resolved configuration with the token redacted.

--- a/main_test.go
+++ b/main_test.go
@@ -14,7 +14,7 @@ import (
 // --- parseArgs tests ---
 
 func TestParseArgs_HelpLong(t *testing.T) {
-	verbose, version, showHelp, printEnv, model, upstream, logFile, profile, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{"--help"})
+	verbose, version, showHelp, printEnv, model, upstream, logFile, profile, _, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{"--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true for --help")
 	}
@@ -24,91 +24,91 @@ func TestParseArgs_HelpLong(t *testing.T) {
 }
 
 func TestParseArgs_HelpShort(t *testing.T) {
-	_, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
+	_, _, showHelp, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-h"})
 	if !showHelp {
 		t.Error("expected showHelp=true for -h")
 	}
 }
 
 func TestParseArgs_PrintEnv(t *testing.T) {
-	_, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
+	_, _, _, printEnv, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--print-env"})
 	if !printEnv {
 		t.Error("expected printEnv=true for --print-env")
 	}
 }
 
 func TestParseArgs_Version(t *testing.T) {
-	_, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
+	_, version, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--version"})
 	if !version {
 		t.Error("expected version=true for --version")
 	}
 }
 
 func TestParseArgs_Verbose(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose"})
 	if !verbose {
 		t.Error("expected verbose=true for --verbose")
 	}
 }
 
 func TestParseArgs_VerboseShort(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"-v"})
 	if !verbose {
 		t.Error("expected verbose=true for -v")
 	}
 }
 
 func TestParseArgs_LogFile(t *testing.T) {
-	_, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
+	_, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file", "/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_LogFileEquals(t *testing.T) {
-	_, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
+	_, _, _, _, _, _, logFile, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--log-file=/tmp/test.log"})
 	if logFile != "/tmp/test.log" {
 		t.Errorf("expected logFile=%q, got %q", "/tmp/test.log", logFile)
 	}
 }
 
 func TestParseArgs_Upstream(t *testing.T) {
-	_, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "https://gw.example.com/openai/v1"})
+	_, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream", "https://gw.example.com/openai/v1"})
 	if upstream != "https://gw.example.com/openai/v1" {
 		t.Errorf("expected upstream=%q, got %q", "https://gw.example.com/openai/v1", upstream)
 	}
 }
 
 func TestParseArgs_UpstreamEquals(t *testing.T) {
-	_, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream=https://gw.example.com/openai/v1"})
+	_, _, _, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--upstream=https://gw.example.com/openai/v1"})
 	if upstream != "https://gw.example.com/openai/v1" {
 		t.Errorf("expected upstream=%q, got %q", "https://gw.example.com/openai/v1", upstream)
 	}
 }
 
 func TestParseArgs_Model(t *testing.T) {
-	_, _, _, _, model, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--model", "gpt-4o"})
+	_, _, _, _, model, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--model", "gpt-4o"})
 	if model != "gpt-4o" {
 		t.Errorf("expected model=%q, got %q", "gpt-4o", model)
 	}
 }
 
 func TestParseArgs_ModelEquals(t *testing.T) {
-	_, _, _, _, model, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--model=gpt-4o"})
+	_, _, _, _, model, _, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--model=gpt-4o"})
 	if model != "gpt-4o" {
 		t.Errorf("expected model=%q, got %q", "gpt-4o", model)
 	}
 }
 
 func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{"--unknown"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{"--unknown"})
 	if len(opencodeArgs) != 1 || opencodeArgs[0] != "--unknown" {
 		t.Errorf("expected opencodeArgs=[\"--unknown\"], got %v", opencodeArgs)
 	}
 }
 
 func TestParseArgs_EmptyArgs(t *testing.T) {
-	verbose, version, showHelp, printEnv, model, upstream, logFile, profile, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{})
+	verbose, version, showHelp, printEnv, model, upstream, logFile, profile, _, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{})
 	if verbose || version || showHelp || printEnv {
 		t.Error("expected all bool flags false for empty args")
 	}
@@ -130,7 +130,7 @@ func TestParseArgs_EmptyArgs(t *testing.T) {
 }
 
 func TestParseArgs_Mixed(t *testing.T) {
-	verbose, _, showHelp, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose", "--upstream", "https://gw.example.com", "--help"})
+	verbose, _, showHelp, _, _, upstream, _, _, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--verbose", "--upstream", "https://gw.example.com", "--help"})
 	if !showHelp {
 		t.Error("expected showHelp=true")
 	}
@@ -143,7 +143,7 @@ func TestParseArgs_Mixed(t *testing.T) {
 }
 
 func TestParseArgs_Separator(t *testing.T) {
-	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{"--verbose", "--", "--unknown", "arg1"})
+	verbose, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{"--verbose", "--", "--unknown", "arg1"})
 	if !verbose {
 		t.Error("expected verbose=true before separator")
 	}
@@ -153,7 +153,7 @@ func TestParseArgs_Separator(t *testing.T) {
 }
 
 func TestParseArgs_PassthroughArgs(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{"prompt text", "--some-flag", "value"})
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs([]string{"prompt text", "--some-flag", "value"})
 	if len(opencodeArgs) != 3 {
 		t.Errorf("expected 3 opencodeArgs, got %d: %v", len(opencodeArgs), opencodeArgs)
 	}
@@ -257,7 +257,7 @@ func TestParseArgs_Table(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			verbose, version, showHelp, printEnv, model, upstream, logFile, profile, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs(tc.args)
+			verbose, version, showHelp, printEnv, model, upstream, logFile, profile, _, _, _, _, _, _, _, _, _, _, opencodeArgs := parseArgs(tc.args)
 
 			if verbose != tc.want.verbose {
 				t.Errorf("verbose: got %v, want %v", verbose, tc.want.verbose)
@@ -415,14 +415,14 @@ func TestHandleHelp_ContainsOpenCodeCLISeparator(t *testing.T) {
 }
 
 func TestParseArgs_Profile(t *testing.T) {
-	_, _, _, _, _, _, _, profile, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "aidev"})
+	_, _, _, _, _, _, _, profile, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile", "aidev"})
 	if profile != "aidev" {
 		t.Errorf("expected profile=%q, got %q", "aidev", profile)
 	}
 }
 
 func TestParseArgs_ProfileEquals(t *testing.T) {
-	_, _, _, _, _, _, _, profile, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile=production"})
+	_, _, _, _, _, _, _, profile, _, _, _, _, _, _, _, _, _, _, _ := parseArgs([]string{"--profile=production"})
 	if profile != "production" {
 		t.Errorf("expected profile=%q, got %q", "production", profile)
 	}
@@ -508,28 +508,35 @@ func TestProfileResolution_DefaultWhenNoStateFile(t *testing.T) {
 }
 
 func TestParseArgs_Port(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, port, _, _, _, _, _, _ := parseArgs([]string{"--port", "8080"})
+	_, _, _, _, _, _, _, _, _, _, _, port, _, _, _, _, _, _, _ := parseArgs([]string{"--port", "8080"})
 	if port != 8080 {
 		t.Errorf("expected port=8080, got %d", port)
 	}
 }
 
 func TestParseArgs_PortEquals(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, port, _, _, _, _, _, _ := parseArgs([]string{"--port=9000"})
+	_, _, _, _, _, _, _, _, _, _, _, port, _, _, _, _, _, _, _ := parseArgs([]string{"--port=9000"})
 	if port != 9000 {
 		t.Errorf("expected port=9000, got %d", port)
 	}
 }
 
 func TestParseArgs_Headless(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, headless, _, _, _, _, _ := parseArgs([]string{"--headless"})
+	_, _, _, _, _, _, _, _, _, _, _, _, headless, _, _, _, _, _, _ := parseArgs([]string{"--headless"})
 	if !headless {
 		t.Error("expected headless=true for --headless")
 	}
 }
 
+func TestParseArgs_NoUpdateCheck(t *testing.T) {
+	_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, noUpdateCheck, _ := parseArgs([]string{"--no-update-check"})
+	if !noUpdateCheck {
+		t.Error("expected noUpdateCheck=true for --no-update-check")
+	}
+}
+
 func TestParseArgs_HeadlessDefault(t *testing.T) {
-	_, _, _, _, _, _, _, _, _, _, _, _, headless, _, _, _, _, _ := parseArgs([]string{})
+	_, _, _, _, _, _, _, _, _, _, _, _, headless, _, _, _, _, _, _ := parseArgs([]string{})
 	if headless {
 		t.Error("expected headless=false for empty args")
 	}
@@ -539,7 +546,7 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp("")
 	})
-	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--model", "--version", "--help", "--port", "--headless", "--idle-timeout", "--install-hooks", "--uninstall-hooks", "--headless-ensure"}
+	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--model", "--version", "--help", "--port", "--headless", "--idle-timeout", "--install-hooks", "--uninstall-hooks", "--headless-ensure", "--no-update-check"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
 			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)


### PR DESCRIPTION
## Summary

Wires `pkg/updater` from databricks-claude v0.11.0 into databricks-opencode:

- `databricks-opencode update` subcommand — force-checks GitHub for newer release (CacheTTL=0, 10s timeout) and prints upgrade instructions (Homebrew or direct download)
- Synchronous startup check before child launch (2s timeout, 24h cache). Cache hits are sub-ms; cold misses that exceed 2s are silently skipped.
- `--no-update-check` flag and `DATABRICKS_NO_UPDATE_CHECK=1` env var to opt out
- `buildUpdaterConfig` / `printUpdateNotice` helpers with cache at `~/.config/opencode/.update-check.json`
- Help text updated with Subcommands section
- README section documenting update check behavior and opt-out

## Test plan

- All existing tests updated for new `noUpdateCheck` return value from `parseArgs`
- New `TestParseArgs_NoUpdateCheck` test added
- `go build ./...`, `go test ./...` all pass

Closes #52