### PR TITLE
feat: add update subcommand and startup update check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/IceRhymers/databricks-opencode
 go 1.22
 
 require (
-	github.com/IceRhymers/databricks-claude v0.11.0
+	github.com/IceRhymers/databricks-claude v0.12.0
 	github.com/tidwall/jsonc v0.3.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/IceRhymers/databricks-claude v0.11.0 h1:VjR+gSPYDINk7DJEI4kR9UP6mRIoyzPoB1wsy7DJBn4=
-github.com/IceRhymers/databricks-claude v0.11.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
+github.com/IceRhymers/databricks-claude v0.12.0 h1:kKQqKNj0N8F4bmujfI504LKzvaa6VZvd2kLmB27xWUI=
+github.com/IceRhymers/databricks-claude v0.12.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
 github.com/tidwall/jsonc v0.3.2 h1:ZTKrmejRlAJYdn0kcaFqRAKlxxFIC21pYq8vLa4p2Wc=
 github.com/tidwall/jsonc v0.3.2/go.mod h1:dw+3CIxqHi+t8eFSpzzMlcVYxKp08UP5CD8/uSFCyJE=


### PR DESCRIPTION
## Summary

- Bumps `databricks-claude` from v0.11.0 to v0.12.0 (the official release containing `pkg/updater`)
- The `update` subcommand and startup update check were already implemented in prior commits against v0.11.0 -- this PR pins the dependency to the stable v0.12.0 release

## What's included (already in master, enabled by this bump)

- `databricks-opencode update` subcommand: force-fresh GitHub release check with 10s timeout, prints upgrade instructions (Homebrew or direct download), exits 0 if up-to-date, exits 1 on error
- Startup update check via `pkg/updater.Check` before child process launch (2s timeout, 24h cache)
- `--no-update-check` flag and `DATABRICKS_NO_UPDATE_CHECK=1` env var opt-out for both
- `update` listed in `--help` output and shell completions
- README documentation for the update subcommand and opt-out

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `go vet ./...` passes