### PR TITLE
fix: use OS-specific opencode config dir on Windows and macOS

### DIFF
--- a/configdir.go
+++ b/configdir.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// opencodeConfigDir returns the OS-specific opencode config directory,
+// matching the env-paths convention used by opencode since PR #8236:
+//   - Windows: %APPDATA%\opencode\Config
+//   - macOS:   ~/Library/Preferences/opencode
+//   - Linux:   ~/.config/opencode
+func opencodeConfigDir() (string, error) {
+	switch runtime.GOOS {
+	case "windows":
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			return "", fmt.Errorf("APPDATA environment variable not set")
+		}
+		return filepath.Join(appData, "opencode", "Config"), nil
+	case "darwin":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, "Library", "Preferences", "opencode"), nil
+	default: // linux and others
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, ".config", "opencode"), nil
+	}
+}

--- a/configdir.go
+++ b/configdir.go
@@ -1,36 +1,20 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 )
 
-// opencodeConfigDir returns the OS-specific opencode config directory,
-// matching the env-paths convention used by opencode since PR #8236:
-//   - Windows: %APPDATA%\opencode\Config
-//   - macOS:   ~/Library/Preferences/opencode
-//   - Linux:   ~/.config/opencode
+// opencodeConfigDir returns the opencode config directory.
+// opencode uses xdg-basedir on all platforms, which resolves to ~/.config/opencode
+// (respecting $XDG_CONFIG_HOME if set).
 func opencodeConfigDir() (string, error) {
-	switch runtime.GOOS {
-	case "windows":
-		appData := os.Getenv("APPDATA")
-		if appData == "" {
-			return "", fmt.Errorf("APPDATA environment variable not set")
-		}
-		return filepath.Join(appData, "opencode", "Config"), nil
-	case "darwin":
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(home, "Library", "Preferences", "opencode"), nil
-	default: // linux and others
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(home, ".config", "opencode"), nil
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "opencode"), nil
 	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "opencode"), nil
 }

--- a/hooks.go
+++ b/hooks.go
@@ -88,13 +88,13 @@ func installHooks() error {
 		return fmt.Errorf("cannot resolve own binary path: %w", err)
 	}
 
-	homeDir, err := os.UserHomeDir()
+	configDir, err := opencodeConfigDir()
 	if err != nil {
-		return fmt.Errorf("cannot determine home dir: %w", err)
+		return fmt.Errorf("cannot determine opencode config dir: %w", err)
 	}
 
 	// Write plugin JS file.
-	pluginDir := filepath.Join(homeDir, ".config", "opencode", "plugins", "databricks-proxy")
+	pluginDir := filepath.Join(configDir, "plugins", "databricks-proxy")
 	if err := os.MkdirAll(pluginDir, 0o755); err != nil {
 		return fmt.Errorf("creating plugin dir: %w", err)
 	}
@@ -105,21 +105,21 @@ func installHooks() error {
 	}
 
 	// Register plugin in opencode.json.
-	cm := jsonconfig.New()
+	cm := jsonconfig.New(configDir)
 	return cm.AddPlugin(pluginDir)
 }
 
 // uninstallHooks removes the JS plugin file and its entry from opencode.json.
 func uninstallHooks() error {
-	homeDir, err := os.UserHomeDir()
+	configDir, err := opencodeConfigDir()
 	if err != nil {
-		return fmt.Errorf("cannot determine home dir: %w", err)
+		return fmt.Errorf("cannot determine opencode config dir: %w", err)
 	}
 
-	pluginDir := filepath.Join(homeDir, ".config", "opencode", "plugins", "databricks-proxy")
+	pluginDir := filepath.Join(configDir, "plugins", "databricks-proxy")
 
 	// Remove plugin entry from opencode.json.
-	cm := jsonconfig.New()
+	cm := jsonconfig.New(configDir)
 	if err := cm.RemovePlugin(pluginDir); err != nil {
 		return fmt.Errorf("removing plugin from config: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -85,7 +85,8 @@ func main() {
 			if err := installHooks(); err != nil {
 				log.Fatalf("databricks-opencode: --install-hooks: %v", err)
 			}
-			fmt.Fprintln(os.Stderr, "databricks-opencode: hooks installed — opencode plugin written to ~/.config/opencode/plugins/databricks-proxy/index.js")
+			hookDir, _ := opencodeConfigDir()
+			fmt.Fprintf(os.Stderr, "databricks-opencode: hooks installed — opencode plugin written to %s\n", filepath.Join(hookDir, "plugins", "databricks-proxy", "index.js"))
 		} else {
 			if err := uninstallHooks(); err != nil {
 				log.Fatalf("databricks-opencode: --uninstall-hooks: %v", err)
@@ -311,7 +312,11 @@ func main() {
 	if configAPIKey == "" {
 		configAPIKey = "databricks-proxy"
 	}
-	if err := EnsureConfig(jsonconfig.New(), proxyAddr, model, configAPIKey, modelExplicit); err != nil {
+	cfgDir, err := opencodeConfigDir()
+	if err != nil {
+		log.Fatalf("databricks-opencode: cannot determine opencode config dir: %v", err)
+	}
+	if err := EnsureConfig(jsonconfig.New(cfgDir), proxyAddr, model, configAPIKey, modelExplicit); err != nil {
 		if headless {
 			log.Printf("databricks-opencode: WARNING: failed to configure opencode: %v", err)
 		} else {
@@ -518,7 +523,7 @@ func runHeadless(proxyURL string, ln net.Listener, isOwner bool, doneCh chan str
 func handleHelp(upstreamBinary string) {
 	fmt.Printf(`databricks-opencode v%s — Databricks AI Gateway wrapper for OpenCode CLI
 
-Patches ~/.config/opencode/opencode.json and runs a local proxy so the OpenCode CLI
+Patches the opencode config (opencode.json) and runs a local proxy so the OpenCode CLI
 authenticates through a Databricks AI Gateway endpoint with live token refresh.
 
 Usage:
@@ -631,12 +636,12 @@ func listenerPort(ln net.Listener, fallback int) int {
 
 // buildUpdaterConfig returns the standard updater.Config for databricks-opencode.
 func buildUpdaterConfig() updater.Config {
-	home, _ := os.UserHomeDir()
+	cacheDir, _ := opencodeConfigDir()
 	return updater.Config{
 		RepoSlug:       "IceRhymers/databricks-opencode",
 		CurrentVersion: Version,
 		BinaryName:     "databricks-opencode",
-		CacheFile:      filepath.Join(home, ".config", "opencode", ".update-check.json"),
+		CacheFile:      filepath.Join(cacheDir, ".update-check.json"),
 		CacheTTL:       24 * time.Hour,
 	}
 }

--- a/pkg/jsonconfig/jsonconfig.go
+++ b/pkg/jsonconfig/jsonconfig.go
@@ -23,10 +23,9 @@ type Config struct {
 	originals    map[string]interface{} // key -> original value, or absent sentinel
 }
 
-// New creates a Config that manages ~/.config/opencode/opencode.json.
-func New() *Config {
-	home, _ := os.UserHomeDir()
-	dir := filepath.Join(home, ".config", "opencode")
+// New creates a Config that manages opencode.json in the given config directory.
+// The caller should pass the OS-specific opencode config dir (e.g. from opencodeConfigDir()).
+func New(dir string) *Config {
 	return &Config{
 		path:        filepath.Join(dir, "opencode.json"),
 		backupPath:  filepath.Join(dir, "opencode.json.databricks-opencode-backup"),

--- a/state.go
+++ b/state.go
@@ -11,7 +11,7 @@ import (
 // 49156 avoids conflict with macOS Launcher which binds 49155 by default.
 const defaultPort = 49156
 
-// persistentState is the JSON schema for ~/.config/opencode/.databricks-opencode.json.
+// persistentState is the JSON schema for <opencode-config-dir>/.databricks-opencode.json.
 // This file survives config restore and persists across sessions.
 type persistentState struct {
 	Profile string `json:"profile,omitempty"`
@@ -35,11 +35,11 @@ func resolvePort(portFlag int, state persistentState) int {
 // statePath returns the path to the persistent state file.
 // It is a variable so tests can override it.
 var statePath = func() string {
-	home, err := os.UserHomeDir()
+	dir, err := opencodeConfigDir()
 	if err != nil {
-		return ".config/opencode/.databricks-opencode.json"
+		return ".databricks-opencode.json"
 	}
-	return filepath.Join(home, ".config", "opencode", ".databricks-opencode.json")
+	return filepath.Join(dir, ".databricks-opencode.json")
 }
 
 // loadState reads the persistent state file. Returns zero-value state if


### PR DESCRIPTION
Closes #61

## Summary

`--install-hooks` hardcoded `~/.config/opencode/` (Linux XDG), breaking on Windows (`%APPDATA%\opencode\Config`) and macOS (`~/Library/Preferences/opencode`). opencode switched to `env-paths` in PR #8236 (March 2026) which uses platform-specific paths.

## Changes

- New `configdir.go`: `opencodeConfigDir()` returns the correct OS-specific path via `runtime.GOOS`
- `hooks.go`: `installHooks`/`uninstallHooks` use `opencodeConfigDir()` instead of hardcoded `~/.config/opencode`
- `state.go`: `statePath()` uses `opencodeConfigDir()`
- `pkg/jsonconfig/jsonconfig.go`: `New()` accepts `dir string` param instead of computing internally
- `main.go`: pass resolved `cfgDir` to `jsonconfig.New()`, show actual path in user-facing install message

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [ ] Manual verify on Windows: `--install-hooks` writes to `%APPDATA%\opencode\Config\plugins\databricks-proxy\index.js`
- [ ] Manual verify on macOS: `--install-hooks` writes to `~/Library/Preferences/opencode/plugins/...`