### PR TITLE
refactor: replace local helpers with shared pkg/ packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/IceRhymers/databricks-opencode
 go 1.22
 
 require (
-	github.com/IceRhymers/databricks-claude v0.12.0
+	github.com/IceRhymers/databricks-claude v0.12.1
 	github.com/tidwall/jsonc v0.3.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/IceRhymers/databricks-claude v0.12.0 h1:kKQqKNj0N8F4bmujfI504LKzvaa6VZvd2kLmB27xWUI=
-github.com/IceRhymers/databricks-claude v0.12.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
+github.com/IceRhymers/databricks-claude v0.12.1 h1:tnJwn84sxvSm489tQ2TvU7XXSPz4Lk7F2zCaqy2l5hM=
+github.com/IceRhymers/databricks-claude v0.12.1/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
 github.com/tidwall/jsonc v0.3.2 h1:ZTKrmejRlAJYdn0kcaFqRAKlxxFIC21pYq8vLa4p2Wc=
 github.com/tidwall/jsonc v0.3.2/go.mod h1:dw+3CIxqHi+t8eFSpzzMlcVYxKp08UP5CD8/uSFCyJE=

--- a/hooks.go
+++ b/hooks.go
@@ -2,12 +2,11 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"time"
 
+	"github.com/IceRhymers/databricks-claude/pkg/headless"
+	"github.com/IceRhymers/databricks-claude/pkg/refcount"
 	"github.com/IceRhymers/databricks-opencode/pkg/jsonconfig"
 )
 
@@ -18,54 +17,24 @@ import (
 // No refcount is acquired here — OpenCode has no exit hook to release it,
 // so the proxy relies on its idle timeout for shutdown instead.
 func headlessEnsure(port int) {
-	if os.Getenv("DATABRICKS_OPENCODE_MANAGED") == "1" {
-		log.Printf("databricks-opencode: --headless-ensure: skipped (managed session)")
-		return
-	}
-
-	// Determine scheme from saved TLS config.
-	state := loadState()
+	s := loadState()
 	scheme := "http"
-	if state.TLSCert != "" && state.TLSKey != "" {
+	if s.TLSCert != "" {
 		scheme = "https"
 	}
-
-	if proxyHealthy(port, scheme) {
-		return // already running
-	}
-
-	self, err := os.Executable()
-	if err != nil {
-		log.Fatalf("databricks-opencode: --headless-ensure: cannot find self: %v", err)
-	}
-
-	args := []string{"--headless", fmt.Sprintf("--port=%d", port)}
-	if state.TLSCert != "" && state.TLSKey != "" {
-		args = append(args, fmt.Sprintf("--tls-cert=%s", state.TLSCert), fmt.Sprintf("--tls-key=%s", state.TLSKey))
-	}
-	cmd := exec.Command(self, args...)
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-	if err := cmd.Start(); err != nil {
-		log.Fatalf("databricks-opencode: --headless-ensure: failed to start proxy: %v", err)
-	}
-	if err := cmd.Process.Release(); err != nil {
-		log.Printf("databricks-opencode: --headless-ensure: release warning: %v", err)
-	}
-
-	// Poll until healthy or timeout.
-	for i := 0; i < 20; i++ {
-		time.Sleep(500 * time.Millisecond)
-		if proxyHealthy(port, scheme) {
-			return
-		}
-	}
-	log.Fatalf("databricks-opencode: --headless-ensure: proxy did not become healthy within 10s")
+	headless.Ensure(headless.Config{
+		Port:          port,
+		Scheme:        scheme,
+		TLSCert:       s.TLSCert,
+		TLSKey:        s.TLSKey,
+		ManagedEnvVar: "DATABRICKS_OPENCODE_MANAGED",
+		LogPrefix:     "databricks-opencode",
+	})
 }
 
 // refcountPathForPort returns the file path used for cross-process session counting.
 func refcountPathForPort(port int) string {
-	return fmt.Sprintf("%s/.databricks-opencode-sessions-%d", os.TempDir(), port)
+	return refcount.PathForPort(".databricks-opencode-sessions", port)
 }
 
 // pluginJSTemplate is the opencode plugin that ensures the headless proxy is running.

--- a/main.go
+++ b/main.go
@@ -3,25 +3,23 @@ package main
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net"
-	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
 	"github.com/IceRhymers/databricks-claude/pkg/authcheck"
 	"github.com/IceRhymers/databricks-claude/pkg/completion"
+	"github.com/IceRhymers/databricks-claude/pkg/health"
+	"github.com/IceRhymers/databricks-claude/pkg/lifecycle"
 	"github.com/IceRhymers/databricks-claude/pkg/portbind"
 	"github.com/IceRhymers/databricks-claude/pkg/proxy"
 	"github.com/IceRhymers/databricks-claude/pkg/refcount"
@@ -276,14 +274,14 @@ func main() {
 	} else {
 		log.Printf("databricks-opencode: joining existing proxy on :%d", port)
 		// Watch for owner death and take over the proxy if needed.
-		go watchProxy(port, proxyHandler, tlsCert, tlsKey)
+		go health.WatchProxy(port, proxyHandler, tlsCert, tlsKey, "databricks-opencode")
 	}
 
 	proxyScheme := "http"
 	if tlsCert != "" && tlsKey != "" {
 		proxyScheme = "https"
 	}
-	proxyAddr := fmt.Sprintf("%s://127.0.0.1:%d", proxyScheme, listenerPort(listener, port))
+	proxyAddr := fmt.Sprintf("%s://127.0.0.1:%d", proxyScheme, portbind.ListenerPort(listener, port))
 	log.Printf("databricks-opencode: local proxy %s -> %s", proxyAddr, gatewayURL)
 
 	// --- Reference counting (wrapper mode only) ---
@@ -301,7 +299,15 @@ func main() {
 	var doneCh chan struct{}
 	if headless {
 		doneCh = make(chan struct{})
-		proxyHandler = wrapWithLifecycle(proxyHandler, isOwner, idleTimeout, proxyAPIKey, doneCh)
+		proxyHandler = lifecycle.WrapWithLifecycle(lifecycle.Config{
+			Inner:        proxyHandler,
+			RefcountPath: "",
+			IsOwner:      isOwner,
+			IdleTimeout:  idleTimeout,
+			APIKey:       proxyAPIKey,
+			DoneCh:       doneCh,
+			LogPrefix:    "databricks-opencode",
+		})
 	}
 
 	// --- Ensure config.json points at the local proxy (idempotent) ---
@@ -332,7 +338,7 @@ func main() {
 
 	// --- Synchronous update check (before child to avoid stderr interleaving) ---
 	if !noUpdateCheck && os.Getenv("DATABRICKS_NO_UPDATE_CHECK") != "1" {
-		printUpdateNotice(buildUpdaterConfig())
+		updater.PrintUpdateNotice(buildUpdaterConfig())
 	}
 
 	log.Printf("databricks-opencode: launching opencode")
@@ -577,63 +583,6 @@ OpenCode CLI Options:
 	fmt.Print(buf.String())
 }
 
-// proxyHealthy checks whether the proxy on the given port is responding.
-func proxyHealthy(port int, scheme string) bool {
-	client := &http.Client{Timeout: 500 * time.Millisecond}
-	if scheme == "https" {
-		client.Transport = &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-	}
-	resp, err := client.Get(fmt.Sprintf("%s://127.0.0.1:%d/health", scheme, port))
-	if err != nil {
-		return false
-	}
-	resp.Body.Close()
-	return resp.StatusCode == http.StatusOK
-}
-
-// watchProxy polls the proxy health endpoint and takes over the port if the
-// owner process dies. Runs as a goroutine for non-owner sessions.
-func watchProxy(port int, handler http.Handler, tlsCert, tlsKey string) {
-	scheme := "http"
-	if tlsCert != "" && tlsKey != "" {
-		scheme = "https"
-	}
-
-	ticker := time.NewTicker(2 * time.Second)
-	defer ticker.Stop()
-
-	for range ticker.C {
-		if proxyHealthy(port, scheme) {
-			continue
-		}
-
-		// Proxy is unreachable — try to bind the port and take over.
-		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
-		if err != nil {
-			continue // another session grabbed it first
-		}
-		if _, err := proxy.Serve(ln, handler, tlsCert, tlsKey); err != nil {
-			ln.Close()
-			continue
-		}
-		log.Printf("databricks-opencode: proxy owner died, took over on :%d", port)
-		return
-	}
-}
-
-// listenerPort returns the port from the listener, or fallback if ln is nil.
-func listenerPort(ln net.Listener, fallback int) int {
-	if ln == nil {
-		return fallback
-	}
-	if addr, ok := ln.Addr().(*net.TCPAddr); ok {
-		return addr.Port
-	}
-	return fallback
-}
-
 // buildUpdaterConfig returns the standard updater.Config for databricks-opencode.
 func buildUpdaterConfig() updater.Config {
 	cacheDir, _ := opencodeConfigDir()
@@ -643,26 +592,6 @@ func buildUpdaterConfig() updater.Config {
 		BinaryName:     "databricks-opencode",
 		CacheFile:      filepath.Join(cacheDir, ".update-check.json"),
 		CacheTTL:       24 * time.Hour,
-	}
-}
-
-// printUpdateNotice checks for a newer release and prints a one-line notice
-// to stderr. The 2-second timeout ensures cold misses don't delay startup.
-func printUpdateNotice(cfg updater.Config) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	r, err := updater.Check(ctx, cfg)
-	if err != nil {
-		log.Printf("databricks-opencode: update check: %v", err)
-		return
-	}
-	if !r.UpdateAvailable {
-		return
-	}
-	if r.IsHomebrew {
-		fmt.Fprintf(os.Stderr, "databricks-opencode: update available (v%s). Run: brew upgrade databricks-opencode\n", r.LatestVersion)
-	} else {
-		fmt.Fprintf(os.Stderr, "databricks-opencode: update available (v%s). Run: databricks-opencode update\n", r.LatestVersion)
 	}
 }
 
@@ -688,64 +617,3 @@ func handlePrintEnv(databricksHost, openaiBaseURL, token, profile, model string)
 `, profile, model, databricksHost, openaiBaseURL, redacted, opencodePath)
 }
 
-// wrapWithLifecycle wraps the proxy handler with:
-//   - POST /shutdown: immediately triggers proxy shutdown
-//   - Activity tracking: resets the idle timer on every proxied request
-//
-// It returns the wrapped handler. doneCh is closed when shutdown is triggered
-// (either via /shutdown or idle timeout). The caller selects on doneCh to
-// begin cleanup.
-func wrapWithLifecycle(
-	inner http.Handler,
-	isOwner bool,
-	idleTimeout time.Duration,
-	apiKey string,
-	doneCh chan struct{},
-) http.Handler {
-	var shutdownOnce sync.Once
-	triggerShutdown := func() {
-		shutdownOnce.Do(func() { close(doneCh) })
-	}
-
-	// Idle timer: fires once after idleTimeout of inactivity.
-	// Reset on every proxied request. time.AfterFunc is goroutine-safe.
-	var idleTimer *time.Timer
-	if idleTimeout > 0 {
-		idleTimer = time.AfterFunc(idleTimeout, func() {
-			log.Printf("databricks-opencode: idle timeout (%s), shutting down", idleTimeout)
-			triggerShutdown()
-		})
-	}
-
-	mux := http.NewServeMux()
-
-	mux.HandleFunc("/shutdown", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		// Enforce API key if configured.
-		if apiKey != "" {
-			if r.Header.Get("Authorization") != "Bearer "+apiKey {
-				http.Error(w, "Unauthorized", http.StatusUnauthorized)
-				return
-			}
-		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]bool{"exiting": true})
-		if idleTimer != nil {
-			idleTimer.Stop()
-		}
-		triggerShutdown()
-	})
-
-	// All other routes: reset idle timer, then delegate to inner handler.
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if idleTimer != nil {
-			idleTimer.Reset(idleTimeout)
-		}
-		inner.ServeHTTP(w, r)
-	})
-
-	return mux
-}

--- a/state.go
+++ b/state.go
@@ -1,10 +1,9 @@
 package main
 
 import (
-	"encoding/json"
-	"log"
-	"os"
 	"path/filepath"
+
+	"github.com/IceRhymers/databricks-claude/pkg/state"
 )
 
 // defaultPort is the fixed port used by databricks-opencode when no override is given.
@@ -22,14 +21,8 @@ type persistentState struct {
 }
 
 // resolvePort returns the port to use: flag > saved state > defaultPort.
-func resolvePort(portFlag int, state persistentState) int {
-	if portFlag > 0 {
-		return portFlag
-	}
-	if state.Port > 0 {
-		return state.Port
-	}
-	return defaultPort
+func resolvePort(portFlag int, s persistentState) int {
+	return state.ResolvePort(portFlag, s.Port, defaultPort)
 }
 
 // statePath returns the path to the persistent state file.
@@ -45,50 +38,11 @@ var statePath = func() string {
 // loadState reads the persistent state file. Returns zero-value state if
 // the file doesn't exist or can't be parsed.
 func loadState() persistentState {
-	data, err := os.ReadFile(statePath())
-	if err != nil {
-		return persistentState{}
-	}
-	var s persistentState
-	if err := json.Unmarshal(data, &s); err != nil {
-		log.Printf("databricks-opencode: invalid state file, ignoring: %v", err)
-		return persistentState{}
-	}
+	s, _ := state.Load[persistentState](statePath())
 	return s
 }
 
 // saveState writes the persistent state file atomically.
 func saveState(s persistentState) error {
-	data, err := json.MarshalIndent(s, "", "  ")
-	if err != nil {
-		return err
-	}
-	data = append(data, '\n')
-
-	p := statePath()
-	dir := filepath.Dir(p)
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return err
-	}
-
-	tmp, err := os.CreateTemp(dir, ".state-*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	if err := os.Chmod(tmpPath, 0o600); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
-		return err
-	}
-	return os.Rename(tmpPath, p)
+	return state.Save(statePath(), s)
 }


### PR DESCRIPTION
## Summary

Replaces all locally duplicated proxy utility functions with calls to shared `pkg/` packages from `databricks-claude` v0.12.1.

• `state.go`: `saveState`/`loadState`/`resolvePort` bodies replaced with `pkg/state.Save`, `state.Load`, `state.ResolvePort`
• `main.go`: deleted `proxyHealthy`, `watchProxy` → `pkg/health`; `listenerPort` → `pkg/portbind`; `wrapWithLifecycle` → `pkg/lifecycle`; `printUpdateNotice` → `pkg/updater`
• `hooks.go`: `headlessEnsure` body replaced with `pkg/headless.Ensure`; `refcountPathForPort` body replaced with `pkg/refcount.PathForPort`

Net reduction: ~209 lines. No behavior changes.

Closes #60

## Test plan

• `go build ./...` passes
• `go test ./...` passes (all existing tests)
• `go vet ./...` clean