### PR TITLE
feat: add databricks-claude-opus-4-7 and make it the primary default

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -24,3 +24,23 @@ CI pipeline configuration for databricks-opencode.
 5. Build binary: `go build -o databricks-opencode .`
 
 All steps must pass for PR approval.
+
+## Release Process (release-please)
+
+Releases are automated via [release-please](https://github.com/googleapis/release-please). It watches commits merged to `master` and opens a release PR automatically — **but only when commits follow the Conventional Commits format**.
+
+### Commit prefix rules
+
+| Prefix | Version bump | When to use |
+|--------|-------------|-------------|
+| `feat:` | minor (0.X.0) | New user-facing feature or behaviour change |
+| `fix:` | patch (0.0.X) | Bug fix |
+| `feat!:` / `fix!:` / `BREAKING CHANGE:` | major (X.0.0) | Breaking API or behaviour change |
+| `chore:`, `docs:`, `refactor:`, `test:` | none | Internal — **will NOT trigger a release PR** |
+
+### Rules for AI agents
+
+- **Every PR that changes user-facing behaviour must include at least one `feat:` or `fix:` commit.** Without it, release-please skips the run and no release PR is opened.
+- Squash-merge is fine — the squash commit message is what release-please reads.
+- `chore:` is safe for housekeeping (formatting, test updates, doc-only changes) but will not produce a release.
+- If a release PR is unexpectedly missing after a merge, check the release workflow logs: the most common cause is a non-conventional commit message.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+* add `databricks-claude-opus-4-7` to registered model list and promote it to primary default model, replacing `databricks-claude-sonnet-4-6` ([#64](https://github.com/IceRhymers/databricks-opencode/issues/64))
+
 ## [0.5.0](https://github.com/IceRhymers/databricks-opencode/compare/v0.4.1...v0.5.0) (2026-04-10)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## [Unreleased]
-
-### Features
-
-* add `databricks-claude-opus-4-7` to registered model list and promote it to primary default model, replacing `databricks-claude-sonnet-4-6` ([#64](https://github.com/IceRhymers/databricks-opencode/issues/64))
-
 ## [0.5.0](https://github.com/IceRhymers/databricks-opencode/compare/v0.4.1...v0.5.0) (2026-04-10)
 
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ make build
 |------|-------------|
 | `--profile` | Databricks CLI profile (saved to state file; `--profile` flag writes it once; default: "DEFAULT") |
 | `--upstream` | Override the AI Gateway URL (default: auto-discovered) |
-| `--model` | Model to use (saved for future sessions; default: "databricks-claude-sonnet-4-6") |
+| `--model` | Model to use (saved for future sessions; default: "databricks-claude-opus-4-7") |
 | `--port` | Proxy listen port (saved for future sessions; default: 49156) |
 | `--print-env` | Print resolved configuration and exit (token redacted) |
 | `--verbose`, `-v` | Enable debug logging to stderr |

--- a/main.go
+++ b/main.go
@@ -160,7 +160,7 @@ func main() {
 		}
 	}
 	if model == "" {
-		model = "databricks-claude-sonnet-4-6"
+		model = "databricks-claude-opus-4-7"
 	}
 	if modelExplicit {
 		saved := loadState()
@@ -538,7 +538,7 @@ Usage:
 Databricks-OpenCode Flags:
   --profile string      Databricks CLI profile (saved for future sessions; default: env or "DEFAULT")
   --upstream string     Override the AI Gateway URL (default: auto-discovered)
-  --model string        Model to use (default: "databricks-claude-sonnet-4-6")
+  --model string        Model to use (default: "databricks-claude-opus-4-7")
   --print-env           Print resolved configuration and exit (token redacted)
   --verbose, -v         Enable debug logging to stderr
   --log-file string     Write debug logs to a file (combinable with --verbose)

--- a/pkg/jsonconfig/jsonconfig.go
+++ b/pkg/jsonconfig/jsonconfig.go
@@ -146,6 +146,7 @@ func (c *Config) Patch(proxyURL, modelName, apiKey string, forceModel bool) erro
 		// between them in OpenCode's model picker without manual config edits.
 		// The active model is controlled by the top-level "model" key below.
 		"models": map[string]interface{}{
+			"databricks-claude-opus-4-7":   map[string]interface{}{},
 			"databricks-claude-opus-4-6":   map[string]interface{}{},
 			"databricks-claude-opus-4-5":   map[string]interface{}{},
 			"databricks-claude-sonnet-4-6": map[string]interface{}{},


### PR DESCRIPTION
## Summary

- Registers `databricks-claude-opus-4-7` in the model allowlist (`pkg/jsonconfig/jsonconfig.go`)
- Makes `databricks-claude-opus-4-7` the new primary default model (was `databricks-claude-sonnet-4-6`)
- Updates README and help text

Closes #64

Companion to IceRhymers/databricks-claude#87.