### PR TITLE
Simplify ConstructGatewayURL: drop SCIM call, use host-relative AI Gateway path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ A lightweight Go proxy wrapper for OpenCode CLI that routes inference requests t
 |------|---------|
 | `main.go` | Entry point: parses flags, resolves profile/model, discovers gateway URL, starts proxy, patches config, runs opencode |
 | `config.go` | ConfigManager: coordinates config.json patching, file locking, session registry, crash recovery |
-| `token.go` | Token management: databricksFetcher implements tokencache.TokenFetcher via Databricks CLI; host discovery and workspace ID resolution via SCIM |
+| `token.go` | Token management: databricksFetcher implements tokencache.TokenFetcher via Databricks CLI; host discovery |
 | `proxy.go` | ProxyConfig and proxy wrappers; wraps databricks-claude/pkg/proxy |
 | `process.go` | RunOpenCode: executes opencode as a child process with args |
 | `state.go` | loadState/saveState: persists profile and model selection to ~/.config/opencode/.state.json |
@@ -70,8 +70,7 @@ make clean
 
 3. **Host and Gateway URL Discovery**
    - Host discovered via `databricks auth env --profile <profile> --output json` → `DATABRICKS_HOST`
-   - Workspace ID resolved via SCIM `/api/2.0/preview/scim/v2/Me` endpoint, extracted from `x-databricks-org-id` header
-   - Gateway URL: `https://{workspaceId}.ai-gateway.cloud.databricks.com/anthropic` (fallback: `{host}/serving-endpoints/anthropic`)
+   - Gateway URL: `{host}/ai-gateway/anthropic`
 
 4. **Config Patching and Restoration (JSONC-Aware)**
    - Snapshots original values of managed keys before patching (stored in `.databricks-opencode-originals.json` sidecar)

--- a/main.go
+++ b/main.go
@@ -230,7 +230,7 @@ func main() {
 
 	gatewayURL := upstream
 	if gatewayURL == "" {
-		gatewayURL = ConstructGatewayURL(host, initialToken)
+		gatewayURL = ConstructGatewayURL(host)
 	}
 	log.Printf("databricks-opencode: gateway URL: %s", gatewayURL)
 

--- a/token.go
+++ b/token.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
-	"net/http"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/IceRhymers/databricks-claude/pkg/tokencache"
@@ -123,44 +122,9 @@ func DiscoverHost(cmdName, profile string) (string, error) {
 	return host, nil
 }
 
-// ResolveWorkspaceID calls the SCIM /Me endpoint and extracts x-databricks-org-id from response headers.
-func ResolveWorkspaceID(host, token string) (string, error) {
-	client := &http.Client{Timeout: 10 * time.Second}
-
-	req, err := http.NewRequest(http.MethodGet, host+"/api/2.0/preview/scim/v2/Me", nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to build SCIM request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("SCIM request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("SCIM request returned status %d", resp.StatusCode)
-	}
-
-	orgID := resp.Header.Get("x-databricks-org-id")
-	if orgID == "" {
-		return "", fmt.Errorf("x-databricks-org-id header not present in SCIM response")
-	}
-	return orgID, nil
-}
-
 // ConstructGatewayURL builds the AI Gateway URL for the OpenCode proxy endpoint.
-// Format: https://{workspaceId}.ai-gateway.cloud.databricks.com/anthropic
-// Fallback: {host}/serving-endpoints/anthropic
+// Format: {host}/ai-gateway/anthropic
 // Uses /anthropic route with @ai-sdk/anthropic (Messages API).
-func ConstructGatewayURL(host, token string) string {
-	workspaceID, err := ResolveWorkspaceID(host, token)
-	if err != nil {
-		log.Printf("workspace ID resolution failed: %v", err)
-		return host + "/serving-endpoints/anthropic"
-	}
-	gatewayURL := "https://" + workspaceID + ".ai-gateway.cloud.databricks.com/anthropic"
-	log.Printf("resolved workspace ID %s, using gateway URL: %s", workspaceID, gatewayURL)
-	return gatewayURL
+func ConstructGatewayURL(host string) string {
+	return strings.TrimRight(host, "/") + "/ai-gateway/anthropic"
 }

--- a/token_test.go
+++ b/token_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -287,74 +285,35 @@ func TestDiscoverHost_CommandFails(t *testing.T) {
 	}
 }
 
-// TestResolveWorkspaceID_Success: mock server returns org-id header -> extracted.
-func TestResolveWorkspaceID_Success(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("x-databricks-org-id", "1234567890")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	orgID, err := ResolveWorkspaceID(srv.URL, "test-token")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+// TestConstructGatewayURL: verifies the host-relative AI Gateway URL.
+func TestConstructGatewayURL(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{
+			name: "plain host",
+			host: "https://dbc-abc123.cloud.databricks.com",
+			want: "https://dbc-abc123.cloud.databricks.com/ai-gateway/anthropic",
+		},
+		{
+			name: "trailing slash trimmed",
+			host: "https://dbc-abc123.cloud.databricks.com/",
+			want: "https://dbc-abc123.cloud.databricks.com/ai-gateway/anthropic",
+		},
+		{
+			name: "multiple trailing slashes trimmed",
+			host: "https://example.databricks.com///",
+			want: "https://example.databricks.com/ai-gateway/anthropic",
+		},
 	}
-	if orgID != "1234567890" {
-		t.Errorf("got %q, want %q", orgID, "1234567890")
-	}
-}
-
-// TestResolveWorkspaceID_MissingHeader: server returns 200 but no org-id header -> error.
-func TestResolveWorkspaceID_MissingHeader(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	_, err := ResolveWorkspaceID(srv.URL, "test-token")
-	if err == nil {
-		t.Fatal("expected error when org-id header missing, got nil")
-	}
-}
-
-// TestResolveWorkspaceID_Non200: server returns 401 -> error.
-func TestResolveWorkspaceID_Non200(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer srv.Close()
-
-	_, err := ResolveWorkspaceID(srv.URL, "bad-token")
-	if err == nil {
-		t.Fatal("expected error on non-200 status, got nil")
-	}
-}
-
-// TestConstructGatewayURL_WithWorkspaceID: resolves workspace ID -> uses AI Gateway domain.
-func TestConstructGatewayURL_WithWorkspaceID(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("x-databricks-org-id", "9876543210")
-		w.WriteHeader(http.StatusOK)
-	}))
-	defer srv.Close()
-
-	got := ConstructGatewayURL(srv.URL, "test-token")
-	want := "https://9876543210.ai-gateway.cloud.databricks.com/anthropic"
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
-}
-
-// TestConstructGatewayURL_Fallback: resolution fails -> falls back to generic codex endpoint.
-func TestConstructGatewayURL_Fallback(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-	}))
-	defer srv.Close()
-
-	got := ConstructGatewayURL(srv.URL, "bad-token")
-	want := srv.URL + "/serving-endpoints/anthropic"
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ConstructGatewayURL(tc.host)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #68

## Summary

The AI Gateway URL no longer requires a workspace-ID lookup. This drops the SCIM `/Me` call entirely and uses the host-relative path `{host}/ai-gateway/anthropic` directly.

Mirrors the same change that just landed in sibling repo `databricks-claude` (#116, merged).

## Changes

**`token.go`**
- Delete `ResolveWorkspaceID` (SCIM call to fetch `x-databricks-org-id`).
- Rewrite `ConstructGatewayURL` from `(host, token string) string` to `(host string) string` — no token, no network call, no fallback path. Now just `strings.TrimRight(host, "/") + "/ai-gateway/anthropic"`.
- Drop `net/http` and `log` imports (only `ResolveWorkspaceID` / fallback logging used them); add `strings`.

**`token_test.go`**
- Delete `TestResolveWorkspaceID_Success`, `TestResolveWorkspaceID_MissingHeader`, `TestResolveWorkspaceID_Non200`.
- Delete `TestConstructGatewayURL_WithWorkspaceID` and `TestConstructGatewayURL_Fallback`.
- Add table-driven `TestConstructGatewayURL` covering plain host, single trailing slash, and multiple trailing slashes.
- Drop `net/http` and `net/http/httptest` imports.

**`main.go`**
- Update the single call site: `ConstructGatewayURL(host, initialToken)` -> `ConstructGatewayURL(host)`. `initialToken` is still used by `handlePrintEnv`.

No `desktop_config.go` exists in this repo; no other callers were found.

## Test plan

- [ ] CI passes (`go test ./...`)
- [ ] Manual smoke: build the binary and run against a workspace; verify the proxy correctly forwards to `{host}/ai-gateway/anthropic` and OpenCode can complete a request
- [ ] `--print-env` shows the new gateway URL