### PR TITLE
chore: bump databricks-claude to v0.17.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/IceRhymers/databricks-opencode
 go 1.22
 
 require (
-	github.com/IceRhymers/databricks-claude v0.12.1
+	github.com/IceRhymers/databricks-claude v0.17.0
 	github.com/tidwall/jsonc v0.3.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/IceRhymers/databricks-claude v0.12.1 h1:tnJwn84sxvSm489tQ2TvU7XXSPz4Lk7F2zCaqy2l5hM=
-github.com/IceRhymers/databricks-claude v0.12.1/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
+github.com/IceRhymers/databricks-claude v0.17.0 h1:YPJgXMLBMmmr3uhgZWLTPbsikTnYOOpRdiDTWakzoQo=
+github.com/IceRhymers/databricks-claude v0.17.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
 github.com/tidwall/jsonc v0.3.2 h1:ZTKrmejRlAJYdn0kcaFqRAKlxxFIC21pYq8vLa4p2Wc=
 github.com/tidwall/jsonc v0.3.2/go.mod h1:dw+3CIxqHi+t8eFSpzzMlcVYxKp08UP5CD8/uSFCyJE=

--- a/hooks.go
+++ b/hooks.go
@@ -16,13 +16,13 @@ import (
 //
 // No refcount is acquired here — OpenCode has no exit hook to release it,
 // so the proxy relies on its idle timeout for shutdown instead.
-func headlessEnsure(port int) {
+func headlessEnsure(port int) error {
 	s := loadState()
 	scheme := "http"
 	if s.TLSCert != "" {
 		scheme = "https"
 	}
-	headless.Ensure(headless.Config{
+	return headless.Ensure(headless.Config{
 		Port:          port,
 		Scheme:        scheme,
 		TLSCert:       s.TLSCert,

--- a/main.go
+++ b/main.go
@@ -98,7 +98,9 @@ func main() {
 	if headlessEnsureFlag {
 		state := loadState()
 		port := resolvePort(0, state)
-		headlessEnsure(port)
+		if err := headlessEnsure(port); err != nil {
+			log.Fatalf("databricks-opencode: headless ensure failed: %v", err)
+		}
 		os.Exit(0)
 	}
 

--- a/main.go
+++ b/main.go
@@ -175,7 +175,7 @@ func main() {
 	}
 
 	// --- Ensure the user is authenticated before proceeding ---
-	if err := authcheck.EnsureAuthenticated(profile, "opencode"); err != nil {
+	if err := authcheck.EnsureAuthenticated(profile, ""); err != nil {
 		log.Fatalf("databricks-opencode: auth failed: %v", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -173,7 +173,7 @@ func main() {
 	}
 
 	// --- Ensure the user is authenticated before proceeding ---
-	if err := authcheck.EnsureAuthenticated(profile); err != nil {
+	if err := authcheck.EnsureAuthenticated(profile, "opencode"); err != nil {
 		log.Fatalf("databricks-opencode: auth failed: %v", err)
 	}
 
@@ -254,7 +254,7 @@ func main() {
 	}
 
 	// --- Build proxy handler (needed by both owner and watchdog) ---
-	proxyHandler := NewProxyServer(&ProxyConfig{
+	proxyHandler, err := NewProxyServer(&ProxyConfig{
 		InferenceUpstream: gatewayURL,
 		TokenProvider:     tp,
 		Verbose:           verbose,
@@ -262,27 +262,9 @@ func main() {
 		TLSCertFile:       tlsCert,
 		TLSKeyFile:        tlsKey,
 	})
-
-	// --- If we own the listener, start the proxy on it ---
-	if isOwner {
-		servedLn, err := proxy.Serve(listener, proxyHandler, tlsCert, tlsKey)
-		if err != nil {
-			log.Fatalf("databricks-opencode: failed to start proxy: %v", err)
-		}
-		listener = servedLn
-		log.Printf("databricks-opencode: proxy owner on :%d", port)
-	} else {
-		log.Printf("databricks-opencode: joining existing proxy on :%d", port)
-		// Watch for owner death and take over the proxy if needed.
-		go health.WatchProxy(port, proxyHandler, tlsCert, tlsKey, "databricks-opencode")
+	if err != nil {
+		log.Fatalf("databricks-opencode: failed to create proxy server: %v", err)
 	}
-
-	proxyScheme := "http"
-	if tlsCert != "" && tlsKey != "" {
-		proxyScheme = "https"
-	}
-	proxyAddr := fmt.Sprintf("%s://127.0.0.1:%d", proxyScheme, portbind.ListenerPort(listener, port))
-	log.Printf("databricks-opencode: local proxy %s -> %s", proxyAddr, gatewayURL)
 
 	// --- Reference counting (wrapper mode only) ---
 	// In wrapper mode, the parent process acquires here and releases on exit.
@@ -296,19 +278,54 @@ func main() {
 	}
 
 	// In headless mode, wrap handler with /shutdown endpoint and idle timeout.
+	// promoteCh, when non-nil, lets a non-owner be promoted to owner via the
+	// health watcher's onTakeover callback (so /shutdown can fire correctly
+	// after a takeover).
 	var doneCh chan struct{}
+	var promoteCh chan struct{}
 	if headless {
 		doneCh = make(chan struct{})
+		promoteCh = make(chan struct{})
 		proxyHandler = lifecycle.WrapWithLifecycle(lifecycle.Config{
 			Inner:        proxyHandler,
 			RefcountPath: "",
 			IsOwner:      isOwner,
+			PromoteCh:    promoteCh,
 			IdleTimeout:  idleTimeout,
 			APIKey:       proxyAPIKey,
 			DoneCh:       doneCh,
 			LogPrefix:    "databricks-opencode",
 		})
 	}
+
+	// --- If we own the listener, start the proxy on it ---
+	if isOwner {
+		servedLn, err := proxy.Serve(listener, proxyHandler, tlsCert, tlsKey)
+		if err != nil {
+			log.Fatalf("databricks-opencode: failed to start proxy: %v", err)
+		}
+		listener = servedLn
+		log.Printf("databricks-opencode: proxy owner on :%d", port)
+	} else {
+		log.Printf("databricks-opencode: joining existing proxy on :%d", port)
+		// Watch for owner death and take over the proxy if needed.
+		// onTakeover closes promoteCh so the lifecycle wrapper promotes this
+		// process to owner, enabling /shutdown to trigger a clean shutdown.
+		onTakeover := func() {
+			if promoteCh != nil {
+				close(promoteCh)
+			}
+		}
+		go health.WatchProxy(port, proxyHandler, tlsCert, tlsKey, "databricks-opencode", onTakeover)
+	}
+
+	proxyScheme := "http"
+	if tlsCert != "" && tlsKey != "" {
+		proxyScheme = "https"
+	}
+	proxyAddr := fmt.Sprintf("%s://127.0.0.1:%d", proxyScheme, portbind.ListenerPort(listener, port))
+	log.Printf("databricks-opencode: local proxy %s -> %s", proxyAddr, gatewayURL)
+
 
 	// --- Ensure config.json points at the local proxy (idempotent) ---
 	// Use proxyAPIKey if explicitly set; otherwise use a fixed placeholder.

--- a/proxy.go
+++ b/proxy.go
@@ -20,7 +20,7 @@ type ProxyConfig struct {
 
 // NewProxyServer returns an http.Handler that routes requests to the
 // inference upstream. No OTEL upstream is needed for OpenCode.
-func NewProxyServer(config *ProxyConfig) http.Handler {
+func NewProxyServer(config *ProxyConfig) (http.Handler, error) {
 	return proxy.NewServer(&proxy.Config{
 		InferenceUpstream: config.InferenceUpstream,
 		TokenSource:       config.TokenProvider,

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -33,7 +33,10 @@ func TestProxy_InjectsAuthHeader(t *testing.T) {
 		InferenceUpstream: upstream.URL,
 		TokenProvider:     warmToken("test-token-123"),
 	}
-	handler := NewProxyServer(cfg)
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
 	rec := httptest.NewRecorder()
@@ -57,7 +60,10 @@ func TestProxy_RoutesDefaultToInference(t *testing.T) {
 		InferenceUpstream: inference.URL,
 		TokenProvider:     warmToken("tok"),
 	}
-	handler := NewProxyServer(cfg)
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 	rec := httptest.NewRecorder()
@@ -83,7 +89,10 @@ func TestProxy_PreservesRequestBody(t *testing.T) {
 		InferenceUpstream: upstream.URL,
 		TokenProvider:     warmToken("tok"),
 	}
-	handler := NewProxyServer(cfg)
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -118,7 +127,10 @@ func TestProxy_SSEStreaming(t *testing.T) {
 		InferenceUpstream: upstream.URL,
 		TokenProvider:     warmToken("tok"),
 	}
-	handler := NewProxyServer(cfg)
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
 
 	l, err := StartProxy(handler, "", "")
 	if err != nil {


### PR DESCRIPTION
Pulls in v0.13–v0.17 reliability fixes from databricks-claude:

- **sanitize patterns** — broader redaction of secrets in logs
- **empty Bearer guard** — reject empty Authorization tokens
- **WebSocket leak fix** — proper cleanup on disconnect
- **lifecycle takeover wiring** — `PromoteCh` lets a non-owner be promoted to owner via the health watcher's `onTakeover` callback
- **authcheck CLI fallback** — `EnsureAuthenticated(profile, cmdName)` for clearer errors

## Call-site fixes

- `go.mod` — `databricks-claude v0.12.1 → v0.17.0` (`go mod tidy`)
- `proxy.go` — `NewProxyServer` now returns `(http.Handler, error)`
- `main.go` — three changes:
  - `authcheck.EnsureAuthenticated(profile, "")` (added cmdName)
  - `NewProxyServer` error captured and propagated via `log.Fatalf`
  - `health.WatchProxy(..., onTakeover)` callback closes `promoteCh`
  - Reordered: lifecycle wrap (with `PromoteCh`) now happens **before** `WatchProxy` so the channel exists when the watcher needs it
- `proxy_test.go` — updated 4 `NewProxyServer` call sites with error check

## Verification

- `go build ./...` passed
- `go vet ./...` passed
- `go test ./...` passed (all packages, 10.9s)

Closes #71
