### PR TITLE
feat: CLI command-tree restructure (integration branch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, 'feat/**']
   pull_request:
-    branches: [master]
+    branches: [master, 'feat/**']
 
 jobs:
   ci:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,11 @@ A lightweight Go proxy wrapper for OpenCode CLI that routes inference requests t
 
 | File | Purpose |
 |------|---------|
-| `main.go` | Entry point: parses flags, resolves profile/model, discovers gateway URL, starts proxy, patches config, runs opencode |
+| `main.go` | Entry point: parses flags, resolves profile/model, discovers gateway URL, starts proxy, patches config, runs opencode. Hosts `runOpencode` (lifted in #84) so the `serve` dispatcher reuses the same body in headless mode. |
+| `commands.go` | Command-tree registry (rootCommand + config/hooks/serve subcommands) — single source of truth for flag set, help text, and shell completion |
+| `serve_cmd.go` | `serve` subcommand dispatcher (#84) — replaces removed `--headless` / `--idle-timeout` root flags; implements bare-number-is-minutes idle-timeout grammar |
+| `hooks_cmd.go` | `hooks` subcommand dispatcher (#83) — install/uninstall opencode plugin + session-start internal |
+| `config_cmd.go` | `config` subcommand dispatcher (#82) — `config show` replaces removed `--print-env` |
 | `config.go` | EnsureConfig: idempotent patch of config.json (no backup, no restore — config persists pointing at the fixed proxy port) |
 | `token.go` | Token management: databricksFetcher implements tokencache.TokenFetcher via Databricks CLI; host discovery |
 | `proxy.go` | ProxyConfig and proxy wrappers; wraps databricks-claude/pkg/proxy |
@@ -95,9 +99,11 @@ make clean
    - On exit, the patched config is left in place — opencode's persistent config keeps pointing at the local proxy URL across runs, and the next run re-patches only if `NeedsConfig` reports drift
 
 8. **Flag Parsing**
-   - Databricks-opencode flags: `--profile`, `--model`, `--upstream`, `--log-file`, `--verbose`, `--version`, `--help`, `--print-env`, `--proxy-api-key`, `--tls-cert`, `--tls-key`
+   - Databricks-opencode root flags: `--profile`, `--model`, `--upstream`, `--log-file`, `--verbose`, `--version`, `--help`, `--proxy-api-key`, `--tls-cert`, `--tls-key`, `--port`, `--no-update-check`
+   - Subcommands: `completion <shell>`, `update`, `config show`, `hooks {install|uninstall|session-start}`, `serve`
    - Separator: `--` passes remaining args to opencode (e.g., `databricks-opencode -- --chat`)
    - Flags not recognized as databricks-opencode flags are passed through to opencode
+   - Removed in #82/#83/#84: `--print-env` (→ `config show`), `--install-hooks` / `--uninstall-hooks` / `--headless-ensure` (→ `hooks` subcommand), `--headless` / `--idle-timeout` (→ `serve` subcommand)
 
 ### Important Notes for Development
 

--- a/README.md
+++ b/README.md
@@ -71,12 +71,37 @@ make build
 | `--proxy-api-key` | Require this API key on all proxy requests (default: disabled) |
 | `--tls-cert` | Path to TLS certificate file (requires --tls-key) |
 | `--tls-key` | Path to TLS private key file (requires --tls-cert) |
-| `--headless` | Start proxy without launching opencode (for IDE extensions or hooks) |
-| `--idle-timeout` | Idle timeout for headless mode (default 30m; `0` disables; bare number = minutes) |
 | `--version` | Print version and exit |
 | `--help`, `-h` | Show help message |
 
-> **Breaking change (v0.8.0):** `--install-hooks`, `--uninstall-hooks`, and `--headless-ensure` have been removed in favour of the [`hooks` subcommand](#hooks-subcommand) below.
+> **Breaking change (v0.8.0):** `--install-hooks`, `--uninstall-hooks`, and `--headless-ensure` have been removed in favour of the [`hooks` subcommand](#hooks-subcommand) below. `--headless` and `--idle-timeout` have been removed in favour of the [`serve` subcommand](#serve-subcommand) below.
+
+## `serve` Subcommand
+
+Start the local Databricks proxy without launching opencode. Replaces the removed `--headless` / `--idle-timeout` root flags.
+
+| Subcommand | Description |
+|------------|-------------|
+| `serve` | Start the proxy without launching opencode (for IDE extensions or the `hooks` plugin path). Prints `PROXY_URL=…` on stdout and blocks until `POST /shutdown`, the idle timeout fires, or `SIGINT/SIGTERM`. |
+
+```bash
+# Replaces `databricks-opencode --headless`:
+databricks-opencode serve
+
+# Honour --idle-timeout flags (same default 30m; `0` disables; bare number = minutes):
+databricks-opencode serve --idle-timeout 5m
+databricks-opencode serve --idle-timeout 5      # ≡ 5m
+databricks-opencode serve --idle-timeout 0      # disabled
+
+# Override port, profile, TLS, etc — same flag set as the legacy --headless flow:
+databricks-opencode serve --port 49157 --profile aidev --tls-cert cert.pem --tls-key key.pem
+```
+
+`serve` is byte-identical to the legacy `databricks-opencode --headless` flow: discovers the workspace host, constructs the AI Gateway URL, binds `127.0.0.1:<port>` (or joins an existing healthy proxy on that port), patches `~/.config/opencode/opencode.json` to point at the local proxy, prints `PROXY_URL=<scheme>://127.0.0.1:<port>` on stdout, then blocks.
+
+The opencode plugin written by `hooks install` invokes `hooks session-start` at session init, which internally spawns `serve` on the saved port. Users with stale plugins from before v0.8.0 must re-run `hooks install` after upgrading — see the [migration note](#hooks-subcommand) below.
+
+> **Breaking change (v0.8.0):** the `--headless` and `--idle-timeout` root flags have been removed. Use `serve` and `serve --idle-timeout` instead. `serve --idle-timeout 5` (bare number = minutes) is now accepted; the legacy strict-parse error from PR #76 only ever applied to the removed root flag.
 
 ## `config` Subcommand
 
@@ -130,7 +155,7 @@ This writes an OpenCode plugin to `~/.config/opencode/plugins/databricks-proxy/i
 
 ### Shutdown
 
-Unlike Claude Code, OpenCode does not have a session-end hook event. The proxy shuts itself down automatically after **30 minutes of inactivity** (configurable via `--idle-timeout`). You can also stop it manually with `POST /shutdown` or by sending a signal to the process.
+Unlike Claude Code, OpenCode does not have a session-end hook event. The proxy shuts itself down automatically after **30 minutes of inactivity** (configurable via `serve --idle-timeout`). You can also stop it manually with `POST /shutdown` or by sending a signal to the process.
 
 ### Uninstall
 
@@ -145,7 +170,7 @@ Removes only the databricks-opencode plugin file. Other plugins in your opencode
 - Safe to rerun `hooks install` after upgrades — the plugin file is overwritten, not duplicated.
 - Custom port settings persist automatically via the state file (`~/.config/opencode/.databricks-opencode.json`).
 
-> **Migration (v0.8.0):** The legacy root flags `--install-hooks`, `--uninstall-hooks`, and `--headless-ensure` have been removed. **If you have a stale plugin from before v0.8.0**, its session-start invocation still references `--headless-ensure` and will fail at session start. Re-run `databricks-opencode hooks install` once after upgrading to refresh the plugin file. There is no automatic detection — the wrapper does not rewrite plugin files behind your back.
+> **Migration (v0.8.0):** The legacy root flags `--install-hooks`, `--uninstall-hooks`, `--headless-ensure`, `--headless`, and `--idle-timeout` have been removed. **If you have a stale plugin from before v0.8.0**, its session-start invocation references the removed `--headless-ensure` flag and will fail at session start. Re-run `databricks-opencode hooks install` once after upgrading to refresh the plugin file. There is no automatic detection — the wrapper does not rewrite plugin files behind your back.
 
 ## Shell Tab Completions
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ make build
 | `--upstream` | Override the AI Gateway URL (default: auto-discovered) |
 | `--model` | Model to use (saved for future sessions; default: "databricks-claude-opus-4-7") |
 | `--port` | Proxy listen port (saved for future sessions; default: 49156) |
-| `--print-env` | Print resolved configuration and exit (token redacted) |
 | `--verbose`, `-v` | Enable debug logging to stderr |
 | `--log-file` | Write debug logs to a file (combinable with --verbose) |
 | `--proxy-api-key` | Require this API key on all proxy requests (default: disabled) |
@@ -78,6 +77,24 @@ make build
 | `--uninstall-hooks` | Remove databricks-opencode plugin from opencode |
 | `--version` | Print version and exit |
 | `--help`, `-h` | Show help message |
+
+## `config` Subcommand
+
+Diagnostic and persistent-config commands live under `databricks-opencode config <sub>`.
+
+| Subcommand | Description |
+|------------|-------------|
+| `config show` | Print the resolved configuration (profile, host, gateway URL, model, opencode binary) with the auth token redacted. Read-only — replaces the removed `--print-env` root flag. |
+
+```bash
+# Replaces the legacy `databricks-opencode --print-env`:
+databricks-opencode config show
+
+# Override the profile for the dump (does not persist):
+databricks-opencode config show --profile my-workspace
+```
+
+> **Breaking change (v0.8.0):** the `--print-env` root flag has been removed. Use `config show` instead.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ make build
 | `--tls-key` | Path to TLS private key file (requires --tls-cert) |
 | `--headless` | Start proxy without launching opencode (for IDE extensions or hooks) |
 | `--idle-timeout` | Idle timeout for headless mode (default 30m; `0` disables; bare number = minutes) |
-| `--install-hooks` | Install opencode plugin for automatic proxy lifecycle |
-| `--uninstall-hooks` | Remove databricks-opencode plugin from opencode |
 | `--version` | Print version and exit |
 | `--help`, `-h` | Show help message |
+
+> **Breaking change (v0.8.0):** `--install-hooks`, `--uninstall-hooks`, and `--headless-ensure` have been removed in favour of the [`hooks` subcommand](#hooks-subcommand) below.
 
 ## `config` Subcommand
 
@@ -108,19 +108,25 @@ databricks-opencode config show --profile my-workspace
 
 No shell alias needed — `databricks-opencode` is a standalone binary.
 
-## Session Hooks (automatic proxy lifecycle)
+## `hooks` Subcommand
 
-Install hooks so every OpenCode session auto-starts the proxy on startup — no manual `--headless` needed.
+Install hooks so every OpenCode session auto-starts the proxy on startup — no manual `--headless` needed. The `hooks` subcommand consolidates the lifecycle commands that previously lived behind root flags.
+
+| Subcommand | Description |
+|------------|-------------|
+| `hooks install` | Write the opencode plugin and register it in `opencode.json`. Idempotent. |
+| `hooks uninstall` | Remove the databricks-opencode plugin. Tolerates "not installed". |
+| `hooks session-start` | Plugin-invoked internal — start the proxy if not running (replaces the removed `--headless-ensure` root flag). |
 
 > **First-time setup:** Run `databricks-opencode` at least once before installing hooks. This writes `~/.config/opencode/opencode.json` so the proxy is used for all OpenCode sessions.
 
 ### Install
 
 ```bash
-databricks-opencode --install-hooks
+databricks-opencode hooks install
 ```
 
-This writes an OpenCode plugin to `~/.config/opencode/plugins/databricks-proxy/index.js` that runs `databricks-opencode --headless-ensure` at session startup.
+This writes an OpenCode plugin to `~/.config/opencode/plugins/databricks-proxy/index.js` that runs `databricks-opencode hooks session-start` at session startup.
 
 ### Shutdown
 
@@ -129,15 +135,17 @@ Unlike Claude Code, OpenCode does not have a session-end hook event. The proxy s
 ### Uninstall
 
 ```bash
-databricks-opencode --uninstall-hooks
+databricks-opencode hooks uninstall
 ```
 
 Removes only the databricks-opencode plugin file. Other plugins in your opencode plugins directory are untouched.
 
 ### Notes
 
-- Safe to rerun `--install-hooks` after upgrades — the plugin file is overwritten, not duplicated.
+- Safe to rerun `hooks install` after upgrades — the plugin file is overwritten, not duplicated.
 - Custom port settings persist automatically via the state file (`~/.config/opencode/.databricks-opencode.json`).
+
+> **Migration (v0.8.0):** The legacy root flags `--install-hooks`, `--uninstall-hooks`, and `--headless-ensure` have been removed. **If you have a stale plugin from before v0.8.0**, its session-start invocation still references `--headless-ensure` and will fail at session start. Re-run `databricks-opencode hooks install` once after upgrading to refresh the plugin file. There is no automatic detection — the wrapper does not rewrite plugin files behind your back.
 
 ## Shell Tab Completions
 

--- a/commands.go
+++ b/commands.go
@@ -22,11 +22,10 @@ import (
 // TestParseArgsCasesAreDeclaredInRootTree) fail loudly if step 1 and 2
 // drift apart — the tree is the single source of truth.
 //
-// #82 introduces this tree, migrates the *root* command's flag set, and adds
-// the `config show` subcommand (replacing the removed --print-env root flag).
-// hooks/serve flag migrations land in #83/#84. --profile and --port are
-// declared as Persistent so subcommand inheritance works out of the box once
-// those migrations land.
+// #82 introduced this tree and migrated the *root* command's flag set, plus
+// added the `config show` subcommand. #83 added the `hooks` subcommand. #84
+// adds the `serve` subcommand and removes the legacy --headless and
+// --idle-timeout root flags.
 var rootCommand = cmd.Command{
 	Name:  "databricks-opencode",
 	Short: "Databricks AI Gateway wrapper for OpenCode CLI",
@@ -72,8 +71,6 @@ var rootCommand = cmd.Command{
 		{Name: "proxy-api-key", Description: "Require this API key on all proxy requests", TakesArg: true},
 		{Name: "tls-cert", Description: "TLS certificate file for the local proxy (requires --tls-key)", TakesArg: true, Completer: "__files"},
 		{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
-		{Name: "headless", Description: "Start proxy without launching opencode (for IDE extensions or hooks)"},
-		{Name: "idle-timeout", Description: "Idle timeout for headless mode (default 30m; 0 disables; bare number = minutes)", TakesArg: true},
 		{Name: "no-update-check", Description: "Skip the automatic update check on startup", EnvVar: "DATABRICKS_NO_UPDATE_CHECK"},
 	},
 
@@ -87,6 +84,7 @@ var rootCommand = cmd.Command{
 		{Name: "update", Short: "Check for a newer release and print upgrade instructions"},
 		configCommand,
 		hooksCommand,
+		serveCommand,
 	},
 }
 
@@ -146,8 +144,6 @@ Databricks-OpenCode Flags:
   --tls-cert string         Path to TLS certificate file (requires --tls-key)
   --tls-key string          Path to TLS private key file (requires --tls-cert)
   --port int                Local proxy port (default: 49156, saved for future sessions)
-  --headless            Start proxy without launching opencode (for IDE extensions)
-  --idle-timeout duration   Idle timeout for headless mode (default 30m, 0 disables; use e.g. 30s, 5m, 1h)
   --no-update-check            Skip the automatic update check on startup
   --version             Print version and exit
   --help, -h            Show this help message
@@ -166,6 +162,10 @@ Subcommands:
                                  hooks session-start             Plugin-invoked internal
                                                                  (replaces removed root flag)
                                Run 'databricks-opencode hooks --help' for details.
+  serve [flags]                Start the proxy without launching opencode
+                               (for IDE extensions or hooks). Bare number on
+                               the idle-timeout flag = minutes; 0 disables.
+                               Run 'databricks-opencode serve --help' for details.
 
 ────────────────────────────────────────────────────────────────────────────────
 OpenCode CLI Options:
@@ -365,4 +365,87 @@ Replaces the legacy --headless-ensure root flag.
 Flags:
   --port int   Proxy listen port (default: saved state > 49156)
   --help, -h   Show this help message
+`
+
+// serveCommand declares the `serve` subcommand introduced in #84. It
+// consolidates the legacy --headless and --idle-timeout root flags into a
+// discoverable subcommand. Mirrors databricks-claude #174 with the same
+// deliberately smaller scope as databricks-codex #89: no daemon mode and no
+// install/uninstall/status — just the session-scoped proxy lifecycle the
+// removed --headless flag drove.
+//
+// Tree shape:
+//
+//	serve   [--profile P] [--port N] [--upstream URL] [--model M]
+//	        [--proxy-api-key K] [--tls-cert C] [--tls-key K]
+//	        [--log-file F] [--verbose|-v] [--no-update-check]
+//	        [--idle-timeout <dur>]
+//
+// Behavior contract: byte-identical to the removed `databricks-opencode
+// --headless` flow. Boots the proxy, patches opencode.json, prints
+// PROXY_URL=… on stdout, and blocks until /shutdown, idle timeout, or
+// SIGINT/SIGTERM.
+//
+// --idle-timeout grammar: same default (30m) and same `0 = disabled` semantics
+// as the removed root flag, PLUS the AC #84 "bare number = minutes" shape
+// (`--idle-timeout 5` ≡ `--idle-timeout 5m`). The bare-number convenience is
+// new — the pre-#84 root flag was strict (PR #76 rejected bare numbers). The
+// shape is restored under `serve` because the issue spells it out as an AC.
+var serveCommand = cmd.Command{
+	Name:  "serve",
+	Short: "Start the proxy without launching opencode (for IDE extensions or hooks)",
+	Long:  serveHelpTemplate,
+	Flags: []cmd.FlagDef{
+		{Name: "profile", Description: "Databricks CLI profile (default: state file > DEFAULT)", TakesArg: true, Completer: "__databricks_profiles", StateKey: "profile", MDMKey: "databricksProfile", Default: "DEFAULT"},
+		{Name: "port", Description: "Proxy listen port (default: state > 49156)", TakesArg: true, StateKey: "port", Default: "49156"},
+		{Name: "upstream", Description: "Override the AI Gateway URL (default: auto-discovered)", TakesArg: true, Completer: "__files"},
+		{Name: "model", Description: "Model to use (default: databricks-claude-opus-4-7)", TakesArg: true},
+		{Name: "proxy-api-key", Description: "Require this API key on all proxy requests", TakesArg: true},
+		{Name: "tls-cert", Description: "TLS certificate file for the local proxy (requires --tls-key)", TakesArg: true, Completer: "__files"},
+		{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
+		{Name: "log-file", Description: "Write debug logs to file (combinable with --verbose)", TakesArg: true, Completer: "__files"},
+		{Name: "verbose", Short: "v", Description: "Enable debug logging to stderr"},
+		{Name: "no-update-check", Description: "Skip the automatic update check on startup", EnvVar: "DATABRICKS_NO_UPDATE_CHECK"},
+		{Name: "idle-timeout", Description: "Idle timeout (default 30m; 0 disables; bare number = minutes)", TakesArg: true},
+		{Name: "help", Short: "h", Description: "Show help message"},
+	},
+}
+
+const serveHelpTemplate = `Usage: databricks-opencode serve [flags]
+
+Start the local Databricks proxy without launching opencode. Intended for
+IDE extensions, the opencode plugin (see 'hooks session-start'), and any
+host that wants to drive the proxy lifecycle externally.
+
+Replaces the removed --headless and --idle-timeout root flags. Behavior is
+byte-identical to the legacy 'databricks-opencode --headless' flow:
+  - Discovers the workspace host and constructs the AI Gateway URL.
+  - Binds 127.0.0.1:<port> (or joins an existing healthy proxy on that port).
+  - Patches ~/.config/opencode/opencode.json to point at the local proxy.
+  - Prints "PROXY_URL=<scheme>://127.0.0.1:<port>" on stdout.
+  - Blocks until POST /shutdown, the idle timeout fires, or SIGINT/SIGTERM.
+
+Flags:
+  --profile string         Databricks CLI profile (default: state > DEFAULT)
+  --port int               Proxy listen port (default: state > 49156)
+  --upstream string        Override the AI Gateway URL (default: auto-discovered)
+  --model string           Model to use (default: databricks-claude-opus-4-7)
+  --proxy-api-key string   Require this API key on all proxy requests
+  --tls-cert string        TLS certificate file (requires --tls-key)
+  --tls-key string         TLS private key file (requires --tls-cert)
+  --log-file string        Write debug logs to a file
+  --verbose, -v            Enable debug logging to stderr
+  --no-update-check        Skip the automatic update check on startup
+  --idle-timeout duration  Idle timeout (default 30m; 0 disables; bare number = minutes)
+  --help, -h               Show this help message
+
+--idle-timeout examples:
+  --idle-timeout 5m   five minutes
+  --idle-timeout 5    five minutes (bare number = minutes)
+  --idle-timeout 1h   one hour
+  --idle-timeout 0    idle timeout disabled
+
+Migration note (v0.8.0): the legacy root flags --headless and --idle-timeout
+have been removed. Replace 'databricks-opencode --headless' with
+'databricks-opencode serve' (idle-timeout follows as a serve flag).
 `

--- a/commands.go
+++ b/commands.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"github.com/IceRhymers/databricks-opencode/internal/cmd"
+)
+
+// rootCommand is the source-of-truth declaration for the databricks-opencode
+// CLI. It drives:
+//   - parseArgs → knownFlags (the set of "--flag" names the binary owns;
+//     anything else is forwarded transparently to the wrapped opencode binary).
+//   - handleHelp → the help body (rendered from rootCommand.Long).
+//   - completion <shell> → the bash/zsh/fish completion scripts (fed via
+//     pkg/completion using rootCommand.CompletionFlags()).
+//
+// Adding a new root flag requires three edits:
+//  1. Append a FlagDef to Flags (or Persistent for inherited flags) here.
+//  2. Add a case to the switch in parseArgs (main.go) that wires the flag
+//     into the Args struct.
+//  3. Add the matching field to the Args struct.
+//
+// The parity tests in main_test.go (TestRootTreeFlagsAreParseRecognised,
+// TestParseArgsCasesAreDeclaredInRootTree) fail loudly if step 1 and 2
+// drift apart — the tree is the single source of truth.
+//
+// #82 introduces this tree, migrates the *root* command's flag set, and adds
+// the `config show` subcommand (replacing the removed --print-env root flag).
+// hooks/serve flag migrations land in #83/#84. --profile and --port are
+// declared as Persistent so subcommand inheritance works out of the box once
+// those migrations land.
+var rootCommand = cmd.Command{
+	Name:  "databricks-opencode",
+	Short: "Databricks AI Gateway wrapper for OpenCode CLI",
+	Long:  rootHelpTemplate,
+
+	// Persistent flags are inherited by every subcommand once those
+	// commands migrate onto the tree. For now, declaring them here is a
+	// no-op for hooks/headless dispatch (which has its own scanner) but
+	// ensures the tree is shaped correctly for the follow-up.
+	Persistent: []cmd.FlagDef{
+		{
+			Name:        "profile",
+			Description: "Databricks CLI profile (default: DEFAULT)",
+			TakesArg:    true,
+			Completer:   "__databricks_profiles",
+			StateKey:    "profile",
+			MDMKey:      "databricksProfile",
+			Default:     "DEFAULT",
+		},
+		{
+			Name:        "port",
+			Description: "Proxy listen port (default: 49156)",
+			TakesArg:    true,
+			StateKey:    "port",
+			Default:     "49156",
+		},
+	},
+
+	// Order matches the legacy flagDefs slice so the bash/zsh/fish
+	// completion output stays byte-identical with the pre-tree binary.
+	// "profile" is now under Persistent (which renders first in AllFlags),
+	// matching its position-1 spot in the legacy completion output.
+	//
+	// --print-env was removed in #82; its replacement lives at
+	// `databricks-opencode config show`.
+	Flags: []cmd.FlagDef{
+		{Name: "verbose", Short: "v", Description: "Enable debug logging to stderr"},
+		{Name: "version", Description: "Print version and exit"},
+		{Name: "help", Short: "h", Description: "Show help message"},
+		{Name: "model", Description: "Model to use (default: databricks-claude-opus-4-7)", TakesArg: true},
+		{Name: "upstream", Description: "Override upstream opencode binary path", TakesArg: true, Completer: "__files"},
+		{Name: "log-file", Description: "Write debug logs to file (combinable with --verbose)", TakesArg: true, Completer: "__files"},
+		{Name: "proxy-api-key", Description: "Require this API key on all proxy requests", TakesArg: true},
+		{Name: "tls-cert", Description: "TLS certificate file for the local proxy (requires --tls-key)", TakesArg: true, Completer: "__files"},
+		{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
+		{Name: "headless", Description: "Start proxy without launching opencode (for IDE extensions or hooks)"},
+		{Name: "idle-timeout", Description: "Idle timeout for headless mode (default 30m; 0 disables; bare number = minutes)", TakesArg: true},
+		{Name: "install-hooks", Description: "Install opencode plugin for automatic proxy lifecycle"},
+		{Name: "uninstall-hooks", Description: "Remove databricks-opencode plugin from opencode"},
+		{Name: "headless-ensure", Description: "Ensure headless proxy is running (called by opencode plugin)"},
+		{Name: "no-update-check", Description: "Skip the automatic update check on startup", EnvVar: "DATABRICKS_NO_UPDATE_CHECK"},
+	},
+
+	// Subcommands carry their own flags + Long help bodies so handleHelp
+	// renders subcommand-aware help and completion scripts surface child
+	// names. completion / update are leaf commands with their dispatch
+	// still in main(); config has a `show` child whose runner replaces
+	// the removed --print-env root flag.
+	Subcommands: []cmd.Command{
+		{Name: "completion", Short: "Generate shell completion scripts (bash, zsh, fish)"},
+		{Name: "update", Short: "Check for a newer release and print upgrade instructions"},
+		configCommand,
+	},
+}
+
+// configCommand declares the `config` subcommand tree. #82 introduces it
+// with one child — `show` — that lifts the legacy --print-env diagnostic
+// dump under a discoverable subcommand. Future sub-issues may grow this
+// tree (e.g. config write) but the foundation PR is intentionally narrow.
+//
+// Tree shape:
+//
+//	config
+//	└── show           (was --print-env)
+//
+// `show` re-declares --profile and --port locally (instead of relying on
+// root Persistent inheritance) because subcommand parsing still uses each
+// command's flat AllFlags slice — Persistent inheritance from the root is
+// declared in the tree but not yet enforced at parse time.
+var configCommand = cmd.Command{
+	Name:  "config",
+	Short: "Persistent config editor (show)",
+	Long:  configHelpTemplate,
+	Subcommands: []cmd.Command{
+		{
+			Name:  "show",
+			Short: "Print resolved configuration (was --print-env)",
+			Long:  configShowHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "profile", Description: "Databricks CLI profile (default: state file > DEFAULT)", TakesArg: true, Completer: "__databricks_profiles", StateKey: "profile", MDMKey: "databricksProfile", Default: "DEFAULT"},
+				{Name: "port", Description: "Proxy port for the displayed ANTHROPIC_BASE_URL", TakesArg: true, StateKey: "port", Default: "49156"},
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+	},
+}
+
+// rootHelpTemplate is the verbatim help body rendered by handleHelp(). The
+// "{{Version}}" placeholder is substituted by cmd.Render at print time.
+//
+// This template preserves byte-for-byte equivalence with the pre-tree help
+// output, modulo the --print-env removal (replaced by `config show`) and
+// the new `config` line under Subcommands.
+const rootHelpTemplate = `databricks-opencode v{{Version}} — Databricks AI Gateway wrapper for OpenCode CLI
+
+Patches the opencode config (opencode.json) and runs a local proxy so the OpenCode CLI
+authenticates through a Databricks AI Gateway endpoint with live token refresh.
+
+Usage:
+  databricks-opencode [databricks-opencode flags] [opencode flags] [opencode args]
+
+Databricks-OpenCode Flags:
+  --profile string      Databricks CLI profile (saved for future sessions; default: env or "DEFAULT")
+  --upstream string     Override the AI Gateway URL (default: auto-discovered)
+  --model string        Model to use (default: "databricks-claude-opus-4-7")
+  --verbose, -v         Enable debug logging to stderr
+  --log-file string     Write debug logs to a file (combinable with --verbose)
+  --proxy-api-key string    Require this API key on all proxy requests (default: disabled)
+  --tls-cert string         Path to TLS certificate file (requires --tls-key)
+  --tls-key string          Path to TLS private key file (requires --tls-cert)
+  --port int                Local proxy port (default: 49156, saved for future sessions)
+  --headless            Start proxy without launching opencode (for IDE extensions)
+  --idle-timeout duration   Idle timeout for headless mode (default 30m, 0 disables; use e.g. 30s, 5m, 1h)
+  --install-hooks       Install opencode plugin hooks for automatic proxy lifecycle
+  --uninstall-hooks     Remove databricks-opencode plugin from opencode config
+  --headless-ensure     Start proxy if not running (called by opencode plugin at init)
+  --no-update-check            Skip the automatic update check on startup
+  --version             Print version and exit
+  --help, -h            Show this help message
+
+Subcommands:
+  completion <shell>           Generate shell completions (bash, zsh, fish)
+  update                       Check for a newer release and print upgrade instructions
+  config <subcommand>          Persistent config editor.
+                                 config show                     Print resolved config
+                                                                 (replaces the removed
+                                                                 root diagnostic flag)
+                               Run 'databricks-opencode config --help' for details.
+
+────────────────────────────────────────────────────────────────────────────────
+OpenCode CLI Options:
+`
+
+const configHelpTemplate = `Usage: databricks-opencode config <subcommand> [flags]
+
+Persistent config editor. Read-only diagnostics today; future sub-issues may
+grow this tree to cover settings.json mutations. The legacy --print-env root
+flag has been replaced by 'config show'.
+
+Subcommands:
+  show [flags]              Print resolved configuration (token redacted).
+                            Read-only — no writes.
+
+Run 'databricks-opencode config <subcommand> --help' for per-subcommand flags.
+
+Examples:
+  # Diagnostic dump:
+  databricks-opencode config show
+
+  # Override profile for the dump (does not persist):
+  databricks-opencode config show --profile my-workspace
+
+Exit codes:
+  0   success
+  1   discovery / auth failure
+  2   missing or unknown subcommand
+`
+
+const configShowHelpTemplate = `Usage: databricks-opencode config show [flags]
+
+Print the resolved configuration (token redacted) and exit. Read-only —
+zero writes to opencode.json or the state file. Replaces the legacy
+--print-env flag.
+
+Resolves: profile, model, Databricks workspace host, AI Gateway URL,
+ANTHROPIC_AUTH_TOKEN (redacted), and the upstream opencode binary path.
+
+Flags:
+  --profile string   Databricks CLI profile (default: state > DEFAULT)
+  --port int         Port used to display the proxy URL (default: state > 49156)
+  --help, -h         Show this help message
+
+Example output:
+
+  databricks-opencode configuration:
+    Profile:           DEFAULT
+    Model:             databricks-claude-opus-4-7
+    DATABRICKS_HOST:   https://adb-...azuredatabricks.net
+    ANTHROPIC_BASE_URL: https://adb-.../ai-gateway/anthropic
+    Auth Token:         **** (redacted)
+    OpenCode binary:    /usr/local/bin/opencode
+`

--- a/commands.go
+++ b/commands.go
@@ -74,9 +74,6 @@ var rootCommand = cmd.Command{
 		{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
 		{Name: "headless", Description: "Start proxy without launching opencode (for IDE extensions or hooks)"},
 		{Name: "idle-timeout", Description: "Idle timeout for headless mode (default 30m; 0 disables; bare number = minutes)", TakesArg: true},
-		{Name: "install-hooks", Description: "Install opencode plugin for automatic proxy lifecycle"},
-		{Name: "uninstall-hooks", Description: "Remove databricks-opencode plugin from opencode"},
-		{Name: "headless-ensure", Description: "Ensure headless proxy is running (called by opencode plugin)"},
 		{Name: "no-update-check", Description: "Skip the automatic update check on startup", EnvVar: "DATABRICKS_NO_UPDATE_CHECK"},
 	},
 
@@ -89,6 +86,7 @@ var rootCommand = cmd.Command{
 		{Name: "completion", Short: "Generate shell completion scripts (bash, zsh, fish)"},
 		{Name: "update", Short: "Check for a newer release and print upgrade instructions"},
 		configCommand,
+		hooksCommand,
 	},
 }
 
@@ -150,9 +148,6 @@ Databricks-OpenCode Flags:
   --port int                Local proxy port (default: 49156, saved for future sessions)
   --headless            Start proxy without launching opencode (for IDE extensions)
   --idle-timeout duration   Idle timeout for headless mode (default 30m, 0 disables; use e.g. 30s, 5m, 1h)
-  --install-hooks       Install opencode plugin hooks for automatic proxy lifecycle
-  --uninstall-hooks     Remove databricks-opencode plugin from opencode config
-  --headless-ensure     Start proxy if not running (called by opencode plugin at init)
   --no-update-check            Skip the automatic update check on startup
   --version             Print version and exit
   --help, -h            Show this help message
@@ -165,6 +160,12 @@ Subcommands:
                                                                  (replaces the removed
                                                                  root diagnostic flag)
                                Run 'databricks-opencode config --help' for details.
+  hooks <subcommand>           OpenCode plugin lifecycle.
+                                 hooks install                   Install opencode plugin
+                                 hooks uninstall                 Remove opencode plugin
+                                 hooks session-start             Plugin-invoked internal
+                                                                 (replaces removed root flag)
+                               Run 'databricks-opencode hooks --help' for details.
 
 ────────────────────────────────────────────────────────────────────────────────
 OpenCode CLI Options:
@@ -218,4 +219,150 @@ Example output:
     ANTHROPIC_BASE_URL: https://adb-.../ai-gateway/anthropic
     Auth Token:         **** (redacted)
     OpenCode binary:    /usr/local/bin/opencode
+`
+
+// hooksCommand declares the `hooks` subcommand tree introduced in #83.
+// Consolidates the 3 hooks-lifecycle root flags (--install-hooks,
+// --uninstall-hooks, --headless-ensure) under a discoverable subcommand.
+// install/uninstall manage the opencode plugin file at
+// <opencode-config-dir>/plugins/databricks-proxy/index.js;
+// session-start is the plugin-invoked refcount-free proxy lifecycle internal
+// (formerly --headless-ensure).
+//
+// Tree shape:
+//
+//	hooks
+//	├── install        [--profile P] [--port N]
+//	├── uninstall
+//	└── session-start  [--port N]   (plugin-invoked internal)
+//
+// Unlike databricks-claude, OpenCode has no SessionEnd hook event — the
+// proxy shuts itself down on its idle timeout. So there is no
+// `hooks session-end` counterpart.
+//
+// The hook-install logic in hooks.go (installHooks/uninstallHooks/
+// headlessEnsure) is unchanged; this dispatcher is purely a surface reshape
+// so the lifecycle is discoverable and the internal entrypoint stops
+// polluting the user-facing root flag namespace. The plugin JS file emitted
+// by installHooks is updated to invoke `hooks session-start` instead of
+// `--headless-ensure` — users with stale plugins from before #83 must
+// re-run `hooks install` to refresh the file.
+var hooksCommand = cmd.Command{
+	Name:  "hooks",
+	Short: "OpenCode plugin lifecycle: install/uninstall + session-start internal",
+	Long:  hooksHelpTemplate,
+	Subcommands: []cmd.Command{
+		{
+			Name:  "install",
+			Short: "Install the opencode plugin for automatic proxy lifecycle",
+			Long:  hooksInstallHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "profile", Description: "Databricks CLI profile to persist (default: DEFAULT)", TakesArg: true, Completer: "__databricks_profiles", StateKey: "profile", MDMKey: "databricksProfile", Default: "DEFAULT"},
+				{Name: "port", Description: "Proxy listen port to persist (default: 49156)", TakesArg: true, StateKey: "port", Default: "49156"},
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+		{
+			Name:  "uninstall",
+			Short: "Remove the databricks-opencode plugin from opencode",
+			Long:  hooksUninstallHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+		{
+			Name:  "session-start",
+			Short: "Start proxy if not running (invoked by the opencode plugin — internal)",
+			Long:  hooksSessionStartHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "port", Description: "Proxy listen port (default: saved state > 49156)", TakesArg: true, StateKey: "port", Default: "49156"},
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+	},
+}
+
+const hooksHelpTemplate = `Usage: databricks-opencode hooks <subcommand> [flags]
+
+OpenCode plugin lifecycle. Installs an opencode plugin at
+<opencode-config-dir>/plugins/databricks-proxy/index.js that spins the
+local proxy up on session start — making 'databricks-opencode' auto-launch
+with every opencode session without a long-lived daemon.
+
+Subcommands:
+  install        Write the opencode plugin and register it in
+                 opencode.json. Idempotent — safe to re-run after
+                 upgrades.
+  uninstall      Remove the databricks-opencode plugin file and config
+                 entry. Tolerates "not installed".
+  session-start  Plugin-invoked internal: start the proxy if it isn't
+                 already running. Called by the opencode plugin written
+                 by 'hooks install'. Not intended to be invoked directly.
+
+Run 'databricks-opencode hooks <subcommand> --help' for per-subcommand flags.
+
+Examples:
+  # First-time install on a developer machine:
+  databricks-opencode hooks install
+
+  # Remove plugin (e.g. when switching to a different proxy management mode):
+  databricks-opencode hooks uninstall
+
+Migration note (v0.8.0): the legacy root flags --install-hooks,
+--uninstall-hooks, and --headless-ensure have been removed in favour of
+this subcommand. Users with stale plugins from before v0.8.0 must re-run
+'hooks install' so the plugin invokes 'hooks session-start' rather than
+the removed '--headless-ensure' flag.
+
+Exit codes:
+  0   success
+  1   write/discovery failure
+  2   missing or unknown subcommand
+`
+
+const hooksInstallHelpTemplate = `Usage: databricks-opencode hooks install [flags]
+
+Install the opencode plugin so every OpenCode session auto-starts the
+local proxy on session init. Writes the plugin to:
+  <opencode-config-dir>/plugins/databricks-proxy/index.js
+and registers it in opencode.json. Idempotent — safe to re-run after
+upgrades or after switching install methods (Homebrew ↔ go install).
+
+Generated plugin invocation:
+  $` + "`" + `<wrapper> hooks session-start` + "`" + `
+
+Flags:
+  --profile string   Databricks CLI profile to persist (default: DEFAULT)
+  --port int         Proxy listen port to persist (default: 49156)
+  --help, -h         Show this help message
+
+Examples:
+  # First-time install on a developer machine:
+  databricks-opencode hooks install
+
+  # Re-install after upgrade (idempotent):
+  databricks-opencode hooks install
+`
+
+const hooksUninstallHelpTemplate = `Usage: databricks-opencode hooks uninstall
+
+Remove the databricks-opencode plugin file and its entry from
+opencode.json. Tolerates "not installed" — safe to run when no plugin is
+present. Other plugins in your opencode plugins directory are untouched.
+
+Flags:
+  --help, -h   Show this help message
+`
+
+const hooksSessionStartHelpTemplate = `Usage: databricks-opencode hooks session-start [flags]
+
+Plugin-invoked internal: start the local proxy if not already running.
+Called by the opencode plugin file written by 'hooks install'. Not
+intended to be invoked directly by end users.
+
+Replaces the legacy --headless-ensure root flag.
+
+Flags:
+  --port int   Proxy listen port (default: saved state > 49156)
+  --help, -h   Show this help message
 `

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -19,3 +19,13 @@ var flagDefs = func() []completion.FlagDef {
 // Derived from rootCommand so it can never drift from the tree or the
 // completion script.
 var knownFlags = rootCommand.KnownFlags()
+
+// knownSubcommands is the set of top-level subcommands surfaced as
+// position-1 completions when the user types `databricks-opencode <TAB>`.
+// Derived recursively from the root command-tree so nested subcommands
+// (e.g. `hooks install`, `config show`) get nested completion automatically.
+// #83 wires this in so the new `hooks` subcommand and its install /
+// uninstall / session-start children complete out of the box; the same
+// derivation also surfaces `config show` from #82 which had been silently
+// invisible to the completion script.
+var knownSubcommands = rootCommand.CompletionSubcommands()

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -2,43 +2,20 @@ package main
 
 import "github.com/IceRhymers/databricks-claude/pkg/completion"
 
-// flagDefs is the authoritative list of flags owned by databricks-opencode.
-// Everything not listed here is forwarded transparently to the opencode binary.
+// flagDefs is the authoritative list of flags owned by databricks-opencode,
+// derived from rootCommand.CompletionFlags() so the tree is the single
+// source of truth. Anything not listed here is forwarded transparently to
+// the opencode binary.
 //
-// Rules:
-//   - TakesArg: true  → the next token is consumed as the flag's value
-//   - TakesArg: false → the flag is a boolean toggle
-//   - Completer: "__databricks_profiles" → completes from ~/.databrickscfg sections
-//   - Completer: "__files"              → completes with local file paths
-//   - Short: "x"                        → also accepts -x as a short alias
-var flagDefs = []completion.FlagDef{
-	{Name: "profile", Description: "Databricks CLI profile (default: DEFAULT)", TakesArg: true, Completer: "__databricks_profiles"},
-	{Name: "verbose", Short: "v", Description: "Enable debug logging to stderr"},
-	{Name: "version", Description: "Print version and exit"},
-	{Name: "help", Short: "h", Description: "Show help message"},
-	{Name: "print-env", Description: "Print resolved configuration (token redacted) and exit"},
-	{Name: "model", Description: "Model to use (default: databricks-claude-sonnet-4-6)", TakesArg: true},
-	{Name: "upstream", Description: "Override upstream opencode binary path", TakesArg: true, Completer: "__files"},
-	{Name: "log-file", Description: "Write debug logs to file (combinable with --verbose)", TakesArg: true, Completer: "__files"},
-	{Name: "proxy-api-key", Description: "Require this API key on all proxy requests", TakesArg: true},
-	{Name: "tls-cert", Description: "TLS certificate file for the local proxy (requires --tls-key)", TakesArg: true, Completer: "__files"},
-	{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
-	{Name: "port", Description: "Proxy listen port (default: 49156)", TakesArg: true},
-	{Name: "headless", Description: "Start proxy without launching opencode (for IDE extensions or hooks)"},
-	{Name: "idle-timeout", Description: "Idle timeout for headless mode (default 30m; 0 disables; bare number = minutes)", TakesArg: true},
-	{Name: "install-hooks", Description: "Install opencode plugin for automatic proxy lifecycle"},
-	{Name: "uninstall-hooks", Description: "Remove databricks-opencode plugin from opencode"},
-	{Name: "headless-ensure", Description: "Ensure headless proxy is running (called by opencode plugin)"},
-	{Name: "no-update-check", Description: "Skip the automatic update check on startup"},
-}
+// To add a new flag: declare it as a cmd.FlagDef on rootCommand in
+// commands.go (or as Persistent for inherited flags). flagDefs and
+// knownFlags update automatically.
+var flagDefs = func() []completion.FlagDef {
+	return rootCommand.CompletionFlags()
+}()
 
 // knownFlags is the set of flag names (with "--" prefix) that databricks-opencode
 // owns. Anything not in this set is forwarded to the opencode binary.
-// Derived from flagDefs so it can never drift from the completion script.
-var knownFlags = func() map[string]bool {
-	m := make(map[string]bool, len(flagDefs))
-	for _, f := range flagDefs {
-		m["--"+f.Name] = true
-	}
-	return m
-}()
+// Derived from rootCommand so it can never drift from the tree or the
+// completion script.
+var knownFlags = rootCommand.KnownFlags()

--- a/config_cmd.go
+++ b/config_cmd.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/IceRhymers/databricks-claude/pkg/authcheck"
+	"github.com/IceRhymers/databricks-opencode/internal/cmd"
+)
+
+// runConfigCommand implements the `databricks-opencode config ...` dispatcher.
+// args is everything after the literal "config" token. Routes to the show
+// runner today; future sub-issues may grow this tree. Bare `config` (no args)
+// prints help and exits 2 — same convention used by the sibling
+// databricks-claude `config` tree.
+func runConfigCommand(args []string) {
+	if len(args) == 0 {
+		_ = cmd.Render(os.Stderr, configCommand, nil)
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "show":
+		runConfigShow(args[1:])
+	case "--help", "-h", "help":
+		_ = cmd.Render(os.Stdout, configCommand, nil)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "databricks-opencode: unknown config subcommand %q\n\n", args[0])
+		_ = cmd.Render(os.Stderr, configCommand, nil)
+		os.Exit(1)
+	}
+}
+
+// runConfigShow implements `databricks-opencode config show` — the legacy
+// --print-env flow lifted into a subcommand. Read-only diagnostic. Matches
+// the legacy resolution chain (--profile flag > saved state > DEFAULT) and
+// emits byte-identical output to the removed --print-env root flag.
+func runConfigShow(args []string) {
+	node := configCommand.Subcommand("show")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	profile := r.Strings["profile"]
+	saved := loadState()
+	if profile == "" {
+		profile = saved.Profile
+	}
+	if profile == "" {
+		profile = "DEFAULT"
+	}
+
+	// Model resolution mirrors main(): saved state > default constant. No
+	// flag override — `config show` is read-only and a one-shot diagnostic;
+	// surfacing a --model override would imply persistence semantics this
+	// command doesn't have.
+	model := saved.Model
+	if model == "" {
+		model = "databricks-claude-opus-4-7"
+	}
+
+	// Auth check — same gate as the legacy --print-env path.
+	if err := authcheck.EnsureAuthenticated(profile, ""); err != nil {
+		log.Fatalf("databricks-opencode: auth failed: %v", err)
+	}
+
+	// Resolve port (no save). port is not consumed by handlePrintEnv (which
+	// reads ANTHROPIC_BASE_URL from the constructed gatewayURL, not the
+	// proxy URL) but the resolution mirrors --print-env's input set.
+	portFlag := atoiOrZero(r.Strings["port"])
+	if portFlag != 0 {
+		// Resolved but unused — handlePrintEnv prints the gateway URL,
+		// not the proxy URL. Keep the call so future readers see we
+		// considered the proxy port.
+		_ = resolvePort(portFlag, saved)
+	}
+
+	host, err := DiscoverHost("", profile)
+	if err != nil {
+		log.Fatalf("databricks-opencode: failed to discover host: %v\nRun 'databricks auth login' first", err)
+	}
+	gatewayURL := ConstructGatewayURL(host)
+
+	tp := NewTokenProvider("", profile)
+	initialToken, err := tp.Token(context.Background())
+	if err != nil {
+		log.Fatalf("databricks-opencode: failed to fetch initial token: %v", err)
+	}
+
+	handlePrintEnv(host, gatewayURL, initialToken, profile, model)
+}
+
+// atoiOrZero parses s as a base-10 int. Returns 0 on parse failure so
+// resolvePort can fall back to state/default — the same tolerance the
+// hand-rolled --port parsing in parseArgs has.
+func atoiOrZero(s string) int {
+	if s == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/IceRhymers/databricks-opencode
 go 1.22
 
 require (
-	github.com/IceRhymers/databricks-claude v0.17.0
+	github.com/IceRhymers/databricks-claude v1.0.2
 	github.com/tidwall/jsonc v0.3.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/IceRhymers/databricks-claude v0.17.0 h1:YPJgXMLBMmmr3uhgZWLTPbsikTnYOOpRdiDTWakzoQo=
 github.com/IceRhymers/databricks-claude v0.17.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
+github.com/IceRhymers/databricks-claude v1.0.2 h1:kfmmOCDPGCbk8t5mDkLXqIQeLdyDEmW1NGKKW4Kw1cQ=
+github.com/IceRhymers/databricks-claude v1.0.2/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
 github.com/tidwall/jsonc v0.3.2 h1:ZTKrmejRlAJYdn0kcaFqRAKlxxFIC21pYq8vLa4p2Wc=
 github.com/tidwall/jsonc v0.3.2/go.mod h1:dw+3CIxqHi+t8eFSpzzMlcVYxKp08UP5CD8/uSFCyJE=

--- a/hooks.go
+++ b/hooks.go
@@ -16,6 +16,16 @@ import (
 //
 // No refcount is acquired here — OpenCode has no exit hook to release it,
 // so the proxy relies on its idle timeout for shutdown instead.
+//
+// EnsureCommand pins the spawn prefix to []string{"serve"} so the detached
+// child reaches the new (#84) `serve` subcommand instead of the removed
+// --headless root flag — without this override, headless.buildArgs would
+// default to the legacy `--headless --port=N` shape, which after #84 falls
+// through to opencode (since --headless is no longer a known wrapper flag)
+// and the proxy never starts. AC: "Plugin-invoked hooks session-start
+// continues to bring the proxy up correctly — headlessEnsure-equivalent
+// path reuses the serve codepath internally, not the removed --headless
+// flag."
 func headlessEnsure(port int) error {
 	s := loadState()
 	scheme := "http"
@@ -29,6 +39,7 @@ func headlessEnsure(port int) error {
 		TLSKey:        s.TLSKey,
 		ManagedEnvVar: "DATABRICKS_OPENCODE_MANAGED",
 		LogPrefix:     "databricks-opencode",
+		EnsureCommand: []string{"serve"},
 	})
 }
 

--- a/hooks.go
+++ b/hooks.go
@@ -12,7 +12,7 @@ import (
 
 // headlessEnsure checks whether the proxy is healthy on the given port.
 // If not, it starts a detached headless proxy and polls until ready (max 10s).
-// Called by the opencode plugin at init via: databricks-opencode --headless-ensure
+// Called by the opencode plugin at init via: databricks-opencode hooks session-start
 //
 // No refcount is acquired here — OpenCode has no exit hook to release it,
 // so the proxy relies on its idle timeout for shutdown instead.
@@ -42,15 +42,21 @@ func refcountPathForPort(port int) string {
 // Shutdown is handled by the proxy's idle timeout — OpenCode has no exit hook.
 // %s is replaced with the absolute path to the binary at install time so the
 // plugin works regardless of Bun's PATH (which may not include ~/go/bin or /opt/homebrew/bin).
+//
+// The wrapper is invoked via the `hooks session-start` subcommand (introduced
+// in #83). Users on a stale plugin from before #83 will see the old
+// `--headless-ensure` invocation fail at session start — they must re-run
+// `databricks-opencode hooks install` to refresh the plugin file.
 const pluginJSTemplate = `export const DatabricksProxy = async ({ $ }) => {
-  await $` + "`" + `%s --headless-ensure` + "`" + `;
+  await $` + "`" + `%s hooks session-start` + "`" + `;
   return {};
 };
 `
 
 // installHooks writes the JS plugin and registers it in opencode.json.
-// The absolute path to the binary is baked in at install time; rerun --install-hooks after
-// reinstalling via a different method (e.g. switching from go install to Homebrew).
+// The absolute path to the binary is baked in at install time; rerun
+// `hooks install` after reinstalling via a different method (e.g. switching
+// from go install to Homebrew).
 func installHooks() error {
 	self, err := os.Executable()
 	if err != nil {

--- a/hooks_cmd.go
+++ b/hooks_cmd.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/IceRhymers/databricks-opencode/internal/cmd"
+)
+
+// runHooksCommand implements `databricks-opencode hooks ...`. args is
+// everything after the literal "hooks" token. Dispatches install / uninstall
+// / session-start. Bare `hooks` (no args) prints help and exits 2 — same
+// convention as `config` with no action.
+//
+// Introduced in #83 to consolidate the 3 hooks-lifecycle root flags
+// (--install-hooks, --uninstall-hooks, --headless-ensure) off the root
+// command. The hook-install logic and refcount-free proxy lifecycle in
+// hooks.go are unchanged behaviorally; this dispatcher is purely a surface
+// reshape so the lifecycle is discoverable and the internal entrypoint stops
+// polluting the user-facing root flag namespace.
+func runHooksCommand(args []string) {
+	if len(args) == 0 {
+		_ = cmd.Render(os.Stderr, hooksCommand, nil)
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "install":
+		runHooksInstall(args[1:])
+	case "uninstall":
+		runHooksUninstall(args[1:])
+	case "session-start":
+		runHooksSessionStart(args[1:])
+	case "--help", "-h", "help":
+		_ = cmd.Render(os.Stdout, hooksCommand, nil)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "databricks-opencode: unknown hooks subcommand %q\n\n", args[0])
+		_ = cmd.Render(os.Stderr, hooksCommand, nil)
+		os.Exit(1)
+	}
+}
+
+// runHooksInstall implements `databricks-opencode hooks install`. Lifts the
+// pre-#83 --install-hooks block from main.go. Persists profile/port to
+// state when explicitly provided and writes the JS plugin into the opencode
+// plugins directory. Idempotent — re-running overwrites the plugin file
+// rather than duplicating it.
+func runHooksInstall(args []string) {
+	node := hooksCommand.Subcommand("install")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	// Persist explicit profile/port overrides so the plugin's session-start
+	// invocation picks them up via the saved state file. Mirrors the
+	// implicit persistence that the legacy --install-hooks path got via
+	// running through main()'s top-level resolution chain.
+	if profile := r.Strings["profile"]; profile != "" {
+		s := loadState()
+		if s.Profile != profile {
+			s.Profile = profile
+			if err := saveState(s); err != nil {
+				log.Printf("databricks-opencode: failed to save profile: %v", err)
+			}
+		}
+	}
+	if portStr := r.Strings["port"]; portStr != "" {
+		if port := atoiOrZero(portStr); port > 0 {
+			s := loadState()
+			if s.Port != port {
+				s.Port = port
+				if err := saveState(s); err != nil {
+					log.Printf("databricks-opencode: failed to save port: %v", err)
+				}
+			}
+		}
+	}
+
+	if err := installHooks(); err != nil {
+		log.Fatalf("databricks-opencode: hooks install: %v", err)
+	}
+	hookDir, _ := opencodeConfigDir()
+	fmt.Fprintf(os.Stderr, "databricks-opencode: hooks installed — opencode plugin written to %s\n", filepath.Join(hookDir, "plugins", "databricks-proxy", "index.js"))
+}
+
+// runHooksUninstall implements `databricks-opencode hooks uninstall`. Lifts
+// the pre-#83 --uninstall-hooks block from main.go. Tolerates "not
+// installed" — uninstallHooks leaves opencode.json alone when the plugin
+// entry is absent and no-ops on the missing plugin file.
+func runHooksUninstall(args []string) {
+	node := hooksCommand.Subcommand("uninstall")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	if err := uninstallHooks(); err != nil {
+		log.Fatalf("databricks-opencode: hooks uninstall: %v", err)
+	}
+	fmt.Fprintln(os.Stderr, "databricks-opencode: hooks removed from opencode config")
+}
+
+// runHooksSessionStart implements `databricks-opencode hooks session-start`.
+// Plugin-invoked internal — replaces the legacy --headless-ensure flag.
+// Spawns a detached headless proxy if not already healthy on the resolved
+// port. No refcount: OpenCode has no SessionEnd hook to release one, so the
+// proxy relies on its idle timeout for shutdown.
+func runHooksSessionStart(args []string) {
+	node := hooksCommand.Subcommand("session-start")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	state := loadState()
+	port := resolvePort(atoiOrZero(r.Strings["port"]), state)
+	if err := headlessEnsure(port); err != nil {
+		log.Fatalf("databricks-opencode: headless ensure failed: %v", err)
+	}
+}

--- a/hooks_cmd_test.go
+++ b/hooks_cmd_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- #83 hooks tree parity tests ---
+//
+// The command-tree registry in commands.go is the single source of truth for
+// the hooks subcommand surface. These tests pin the tree shape: the children
+// the dispatcher (runHooksCommand) cares about are present, each carries the
+// flags the runner reads from r.Strings/r.Bools, and the top-level node is a
+// pure dispatcher with no flags of its own.
+//
+// Bidirectional verification was performed during #83: temporarily removing
+// `hooksCommand` from rootCommand.Subcommands causes
+// TestHooksCommandTreeParity to fail loudly (rootCommand.Subcommand("hooks")
+// returns nil), confirming the test catches drift in either direction.
+
+// TestHooksCommandTreeParity walks the hooks subcommand tree and asserts the
+// children the dispatcher routes to (install / uninstall / session-start)
+// are declared with the expected flag set. If a runner is added without a
+// tree node — or a flag is plumbed through a runner without being declared
+// on the tree — this test fails loudly so completion + help stay aligned.
+func TestHooksCommandTreeParity(t *testing.T) {
+	root := rootCommand.Subcommand("hooks")
+	if root == nil {
+		t.Fatal("rootCommand should have a `hooks` subcommand declared")
+	}
+	if len(root.AllFlags()) != 0 {
+		t.Errorf("hooks (top-level dispatcher) should declare no flags of its own; got %d", len(root.AllFlags()))
+	}
+
+	cases := []struct {
+		name      string
+		wantFlags []string
+	}{
+		{name: "install", wantFlags: []string{"--profile", "--port", "--help"}},
+		{name: "uninstall", wantFlags: []string{"--help"}},
+		{name: "session-start", wantFlags: []string{"--port", "--help"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			node := hooksCommand.Subcommand(c.name)
+			if node == nil {
+				t.Fatalf("hooksCommand should have a %q child", c.name)
+			}
+			known := node.KnownFlags()
+			for _, want := range c.wantFlags {
+				if !known[want] {
+					t.Errorf("hooks %s missing %q in its known-flag set", c.name, want)
+				}
+			}
+			// Catch the reverse: any flag declared on the tree must be
+			// expected by this assertion. Surfacing a stray flag here means
+			// either the tree gained a flag the runner doesn't read OR this
+			// test went stale; either is a drift signal.
+			for k := range known {
+				found := false
+				for _, want := range c.wantFlags {
+					if k == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("hooks %s has unexpected flag %q (update test or remove flag)", c.name, k)
+				}
+			}
+		})
+	}
+}
+
+// TestHooksCommandHasNestedSubcommands asserts the install/uninstall/
+// session-start children are declared so completion can offer them nested
+// (`databricks-opencode hooks <TAB>` → install/uninstall/session-start).
+// Drives the AC: "Shell completion completes `hooks <TAB>`".
+func TestHooksCommandHasNestedSubcommands(t *testing.T) {
+	want := []string{"install", "uninstall", "session-start"}
+	got := make(map[string]bool, len(hooksCommand.Subcommands))
+	for _, s := range hooksCommand.Subcommands {
+		got[s.Name] = true
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("hooksCommand should have nested `%s` subcommand for nested completion", w)
+		}
+	}
+}
+
+// TestRootCompletionOffersHooksSubcommand asserts `hooks` is surfaced in the
+// root command-tree's CompletionSubcommands output, with all three children
+// reachable through the recursive walk. Without this, `databricks-opencode
+// <TAB>` would not offer `hooks`, and `hooks <TAB>` would not offer the
+// leaves.
+func TestRootCompletionOffersHooksSubcommand(t *testing.T) {
+	for _, sc := range knownSubcommands {
+		if sc.Name == "hooks" {
+			gotChildren := make(map[string]bool, len(sc.Subcommands))
+			for _, child := range sc.Subcommands {
+				gotChildren[child.Name] = true
+			}
+			for _, want := range []string{"install", "uninstall", "session-start"} {
+				if !gotChildren[want] {
+					t.Errorf("knownSubcommands `hooks` is missing nested child %q (recursive completion broken)", want)
+				}
+			}
+			return
+		}
+	}
+	t.Error("knownSubcommands should offer `hooks` as a position-1 subcommand")
+}
+
+// TestPluginJSTemplate_InvokesNewSubcommand is the load-bearing JS-content
+// check: the plugin file must invoke `<wrapper> hooks session-start` (the
+// new subcommand introduced in #83), not the legacy `--headless-ensure` root
+// flag (which #83 removed). Drives the migration callout — users with stale
+// plugins from before #83 see the legacy invocation fail at session start
+// because the flag no longer exists.
+func TestPluginJSTemplate_InvokesNewSubcommand(t *testing.T) {
+	if !strings.Contains(pluginJSTemplate, "hooks session-start") {
+		t.Errorf("pluginJSTemplate should invoke `<wrapper> hooks session-start`, got:\n%s", pluginJSTemplate)
+	}
+	if strings.Contains(pluginJSTemplate, "--headless-ensure") {
+		t.Errorf("pluginJSTemplate must not invoke the removed --headless-ensure flag, got:\n%s", pluginJSTemplate)
+	}
+}
+
+// TestInstallHooksIdempotency walks the full install → install → uninstall →
+// uninstall cycle in an isolated $XDG_CONFIG_HOME and asserts:
+//
+//  1. Re-running install overwrites the plugin file rather than duplicating
+//     it (file content is byte-identical between runs).
+//  2. Re-running uninstall when nothing is installed is a no-op (no error,
+//     no leftover plugin file).
+//
+// Uses t.Setenv("XDG_CONFIG_HOME", …) so opencodeConfigDir resolves to a
+// per-test temp directory without leaking into the user's real config —
+// the critical pitfall called out in the #83 plan.
+func TestInstallHooksIdempotency(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	pluginPath := filepath.Join(dir, "opencode", "plugins", "databricks-proxy", "index.js")
+
+	// --- 1. First install ---
+	if err := installHooks(); err != nil {
+		t.Fatalf("first installHooks: %v", err)
+	}
+	first, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("plugin file missing after first install: %v", err)
+	}
+	if !strings.Contains(string(first), "hooks session-start") {
+		t.Errorf("plugin file should invoke `hooks session-start` after install, got:\n%s", string(first))
+	}
+
+	// --- 2. Second install: byte-identical content (idempotent) ---
+	if err := installHooks(); err != nil {
+		t.Fatalf("second installHooks: %v", err)
+	}
+	second, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("plugin file missing after second install: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("plugin file content should be byte-identical between idempotent installs\nfirst:\n%s\nsecond:\n%s", string(first), string(second))
+	}
+
+	// --- 3. First uninstall: removes plugin file ---
+	if err := uninstallHooks(); err != nil {
+		t.Fatalf("first uninstallHooks: %v", err)
+	}
+	if _, err := os.Stat(pluginPath); !os.IsNotExist(err) {
+		t.Errorf("plugin file should not exist after uninstall; got err=%v", err)
+	}
+
+	// --- 4. Second uninstall: no-op (no error) ---
+	if err := uninstallHooks(); err != nil {
+		t.Errorf("second uninstallHooks should be a no-op when plugin is already absent, got: %v", err)
+	}
+}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -158,6 +158,25 @@ func (c Command) CompletionFlags() []completion.FlagDef {
 	return out
 }
 
+// CompletionSubcommands returns the immediate children as
+// pkg/completion.SubcommandDef. The conversion is RECURSIVE: each child
+// carries its own Flags and Subcommands so the shell-completion generator
+// can offer nested completion (e.g. `hooks <TAB>` → install/uninstall/
+// session-start). Flags include each child's Persistent ++ Flags so
+// inherited flags surface alongside the child's own.
+func (c Command) CompletionSubcommands() []completion.SubcommandDef {
+	out := make([]completion.SubcommandDef, len(c.Subcommands))
+	for i, s := range c.Subcommands {
+		out[i] = completion.SubcommandDef{
+			Name:        s.Name,
+			Description: s.Short,
+			Flags:       s.CompletionFlags(),
+			Subcommands: s.CompletionSubcommands(),
+		}
+	}
+	return out
+}
+
 // KnownFlags returns the set of "--flag" names this command's parser
 // recognises. Includes Persistent ++ Flags. Does NOT walk into
 // Subcommands — each child command is parsed by its own dispatcher and

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -1,0 +1,375 @@
+// Package cmd is the in-repo command-tree registry: a single source of truth
+// for the databricks-opencode CLI surface (flag set, help text, shell
+// completion). The tree is consumed by:
+//
+//   - parseArgs (main package) — derives the set of "--flag" names the
+//     binary recognises; anything not in the tree is forwarded transparently
+//     to the wrapped opencode binary.
+//   - handleHelp (main package) — renders help text from the tree, replacing
+//     the giant hand-maintained printf that previously lived in main.go.
+//   - pkg/completion — receives the tree's CompletionFlags to emit
+//     bash/zsh/fish completion scripts.
+//
+// Boundary: this package MUST NOT import the root main package; the
+// dependency arrow points one way (main → internal/cmd), so the tree can
+// later be lifted to pkg/ without disentangling cycles.
+//
+// Status: #82 introduces the tree and migrates the *root* command's flag set
+// onto it, plus adds the `config show` subcommand. hooks/serve migrations
+// land in #83/#84. The Persistent slice already holds --profile / --port so
+// subcommand inheritance can be wired up when those migrations land.
+package cmd
+
+import (
+	"io"
+	"strings"
+
+	"github.com/IceRhymers/databricks-claude/pkg/completion"
+)
+
+// FlagDef describes one CLI flag. Superset of pkg/completion.FlagDef:
+// carries everything the shell-completion generator needs (Name, Short,
+// Description, TakesArg, Completer) plus resolution-chain metadata
+// (StateKey, EnvVar, MDMKey, Default) so a future tree-driven resolver
+// can derive the flag → env → state → MDM → default lookup order from the
+// same declaration. The resolution-chain fields are CARRIED in #82 but
+// not yet consumed.
+type FlagDef struct {
+	// Name is the flag spelled without the "--" prefix, e.g. "profile".
+	Name string
+	// Short is the optional single-character alias spelled without the "-"
+	// prefix, e.g. "v" for --verbose. Empty means no short alias.
+	Short string
+	// Description is the one-line description shown in help text and
+	// completion scripts. Keep it tight — the help renderer wraps long
+	// descriptions but the completion emitters do not.
+	Description string
+	// TakesArg is true if the flag consumes the next token as its value.
+	TakesArg bool
+	// Completer is the named completer function fed to pkg/completion.
+	// Reserved values: "__databricks_profiles", "__files". Empty means no
+	// value completion (the flag's value is opaque to the shell).
+	Completer string
+
+	// --- Resolution-chain metadata (carried; not yet consumed) ---
+
+	// StateKey is the JSON key under the state file that persists this
+	// flag's value across sessions. Empty if the flag is not persistable.
+	StateKey string
+	// EnvVar is the environment variable that may seed this flag's value
+	// when the flag itself is absent. Empty if the flag has no env tier.
+	EnvVar string
+	// MDMKey is the key under the MDM domain that admins can pin. Empty
+	// if the flag has no MDM tier.
+	MDMKey string
+	// Default is the literal default string when no other tier supplies a
+	// value. Stored as string so the tree stays uniform across types;
+	// callers parse it with strconv when needed.
+	Default string
+}
+
+// ToCompletion narrows a FlagDef to the pkg/completion.FlagDef the shell
+// emitters consume. The resolution-chain metadata is dropped here — it has
+// no completion-script meaning.
+func (f FlagDef) ToCompletion() completion.FlagDef {
+	return completion.FlagDef{
+		Name:        f.Name,
+		Short:       f.Short,
+		Description: f.Description,
+		TakesArg:    f.TakesArg,
+		Completer:   f.Completer,
+	}
+}
+
+// Command is one node in the CLI tree.
+//
+// A Command can be:
+//   - A leaf with Run set (e.g. "completion", "update").
+//   - A branch with Subcommands (e.g. the root, or a future "serve" with
+//     install/uninstall/status children).
+//   - A main-driven node with Run nil (the root, today): main() walks the
+//     tree to derive parsable flags + help text but keeps its own dispatch
+//     loop. Run will be populated when subcommands migrate onto the tree.
+//
+// Persistent flags are conceptually inherited by every subcommand (a child
+// command sees its own Flags ++ every ancestor's Persistent). Inheritance
+// is declared here but not yet enforced at parse time; subcommand parsing
+// still lives in hand-rolled FlagSets pending #83/#84.
+type Command struct {
+	// Name is the command's word as typed on the CLI (e.g. "config").
+	// For the root command, Name is the binary name ("databricks-opencode").
+	Name string
+	// Short is the one-line description shown when this command appears
+	// as a child in a parent's "Subcommands:" listing.
+	Short string
+	// Long is the full help body. When non-empty, Render writes it
+	// verbatim (after substituting registered template variables — see
+	// Render). When empty, Render falls back to a programmatic table
+	// derived from Flags / Persistent / Subcommands. Today the root
+	// carries a hand-formatted Long for byte-for-byte help equivalence
+	// with the legacy printf; future subcommands can opt into the
+	// programmatic renderer by leaving Long empty.
+	Long string
+	// Flags are the flags local to this command.
+	Flags []FlagDef
+	// Persistent flags are inherited by every descendant subcommand.
+	// On the root: --profile and --port live here so they remain
+	// available everywhere once child commands migrate onto the tree.
+	Persistent []FlagDef
+	// Subcommands are the immediate children.
+	Subcommands []Command
+	// Run is the leaf executor. Nil for nodes whose dispatch lives in
+	// main() (the root in #82) or for non-leaf branches whose children
+	// own execution.
+	Run func(args []string) error
+}
+
+// Subcommand returns a pointer to the immediate child Command with the given
+// name, or nil when no such child exists. Helper for runners that dispatch
+// nested subcommands without re-walking the slice each time.
+func (c Command) Subcommand(name string) *Command {
+	for i := range c.Subcommands {
+		if c.Subcommands[i].Name == name {
+			return &c.Subcommands[i]
+		}
+	}
+	return nil
+}
+
+// AllFlags returns Persistent followed by Flags as a single ordered slice.
+// Persistent comes first so subcommand parsing (when it migrates) sees
+// inherited flags before its own; the help renderer follows the same
+// order so persistent flags surface near the top of the flag table.
+func (c Command) AllFlags() []FlagDef {
+	out := make([]FlagDef, 0, len(c.Persistent)+len(c.Flags))
+	out = append(out, c.Persistent...)
+	out = append(out, c.Flags...)
+	return out
+}
+
+// CompletionFlags returns AllFlags converted to pkg/completion.FlagDef so
+// it can be passed straight into completion.Run / GenerateBash / etc.
+func (c Command) CompletionFlags() []completion.FlagDef {
+	flags := c.AllFlags()
+	out := make([]completion.FlagDef, len(flags))
+	for i, f := range flags {
+		out[i] = f.ToCompletion()
+	}
+	return out
+}
+
+// KnownFlags returns the set of "--flag" names this command's parser
+// recognises. Includes Persistent ++ Flags. Does NOT walk into
+// Subcommands — each child command is parsed by its own dispatcher and
+// owns its own KnownFlags.
+func (c Command) KnownFlags() map[string]bool {
+	flags := c.AllFlags()
+	m := make(map[string]bool, len(flags))
+	for _, f := range flags {
+		m["--"+f.Name] = true
+	}
+	return m
+}
+
+// Render writes the command's help body to w. If c.Long is non-empty it
+// is used verbatim, with each "{{key}}" placeholder replaced by vars[key].
+// If c.Long is empty, Render falls back to a programmatic table built
+// from c.Flags / c.Persistent / c.Subcommands (suitable for child
+// commands that migrate onto the tree without curating a Long blob).
+//
+// Today only the root supplies a Long; the programmatic fallback exists
+// so #83/#84 migrations can drop Long with minimal diff.
+func Render(w io.Writer, c Command, vars map[string]string) error {
+	if c.Long != "" {
+		body := c.Long
+		for k, v := range vars {
+			body = strings.ReplaceAll(body, "{{"+k+"}}", v)
+		}
+		_, err := io.WriteString(w, body)
+		return err
+	}
+	return renderProgrammatic(w, c)
+}
+
+// ParseResult is the generic output of Command.Parse. Runners map this into
+// their own typed flag struct (e.g. serveFlags, installFlags) so downstream
+// resolution code is untouched. Three maps so callers can answer the three
+// questions runners actually ask:
+//
+//   - "what string did the user provide for --flag?"     → Strings
+//   - "did the user pass --flag (boolean toggle)?"        → Bools
+//   - "did the user provide --flag at all (used to gate
+//     state-persistence writes via the sentinel guard)?"  → Set
+//
+// Strings and Bools are populated only for known flags (declared on the
+// Command's Persistent + Flags). Unknown flags AND any leftover positional
+// tokens are appended to Positional in input order so runners can still
+// detect e.g. an action keyword or, for the root, forward unknowns to the
+// wrapped opencode binary.
+type ParseResult struct {
+	Strings    map[string]string
+	Bools      map[string]bool
+	Set        map[string]bool
+	Positional []string
+}
+
+// Parse evaluates args against c's known flags (Persistent ++ Flags) and
+// returns a ParseResult. Behavior mirrors the hand-rolled scanners that
+// previously lived in main.go:
+//
+//   - Supports --flag value AND --flag=value forms.
+//   - Boolean flags (TakesArg=false) consume no value. An explicit
+//     --flag=false / --flag=0 / --flag=no sets the bool to false; anything
+//     else (including bare --flag) sets it to true.
+//   - Bare "--" terminates flag parsing; everything after is appended to
+//     Positional verbatim.
+//   - Short aliases declared via FlagDef.Short are honoured (-v → --verbose,
+//     -h → --help when those flags are declared on c).
+//   - Unknown long flags and unknown short flags are appended to Positional
+//     unchanged. This preserves the historical tolerance of the hand-rolled
+//     scanners (which silently ignored unknown flags) and lets root callers
+//     forward unknowns to opencode.
+//   - A TakesArg flag that appears without a value (last token, no "=") gets
+//     an empty string in Strings — matches the hand-rolled scanner behaviour
+//     where bare `--port` left port=0 rather than erroring.
+func (c Command) Parse(args []string) (*ParseResult, error) {
+	flagsByName := make(map[string]FlagDef)
+	flagsByShort := make(map[string]FlagDef)
+	for _, f := range c.AllFlags() {
+		flagsByName[f.Name] = f
+		if f.Short != "" {
+			flagsByShort[f.Short] = f
+		}
+	}
+
+	res := &ParseResult{
+		Strings: map[string]string{},
+		Bools:   map[string]bool{},
+		Set:     map[string]bool{},
+	}
+
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+
+		if a == "--" {
+			res.Positional = append(res.Positional, args[i+1:]...)
+			break
+		}
+
+		if strings.HasPrefix(a, "--") {
+			name := a[2:]
+			value := ""
+			hasValue := false
+			if eq := strings.Index(name, "="); eq >= 0 {
+				value = name[eq+1:]
+				name = name[:eq]
+				hasValue = true
+			}
+			f, known := flagsByName[name]
+			if !known {
+				res.Positional = append(res.Positional, a)
+				continue
+			}
+			if f.TakesArg {
+				if !hasValue && i+1 < len(args) {
+					i++
+					value = args[i]
+				}
+				res.Strings[name] = value
+				res.Set[name] = true
+			} else {
+				res.Bools[name] = !isFalsy(hasValue, value)
+				res.Set[name] = true
+			}
+			continue
+		}
+
+		if len(a) > 1 && a[0] == '-' {
+			short := a[1:]
+			value := ""
+			hasValue := false
+			if eq := strings.Index(short, "="); eq >= 0 {
+				value = short[eq+1:]
+				short = short[:eq]
+				hasValue = true
+			}
+			f, known := flagsByShort[short]
+			if !known {
+				res.Positional = append(res.Positional, a)
+				continue
+			}
+			if f.TakesArg {
+				if !hasValue && i+1 < len(args) {
+					i++
+					value = args[i]
+				}
+				res.Strings[f.Name] = value
+				res.Set[f.Name] = true
+			} else {
+				res.Bools[f.Name] = !isFalsy(hasValue, value)
+				res.Set[f.Name] = true
+			}
+			continue
+		}
+
+		res.Positional = append(res.Positional, a)
+	}
+
+	return res, nil
+}
+
+// isFalsy reports whether an explicit boolean-flag value should set the bool
+// to false. Bare flag (hasValue=false) is always truthy. Explicit values
+// "0", "false", "no" (case-insensitive) are falsy; everything else is truthy.
+func isFalsy(hasValue bool, value string) bool {
+	if !hasValue {
+		return false
+	}
+	return value == "0" || strings.EqualFold(value, "false") || strings.EqualFold(value, "no")
+}
+
+// renderProgrammatic emits a default help layout for commands that don't
+// curate a Long blob. Used by the programmatic fallback in Render.
+func renderProgrammatic(w io.Writer, c Command) error {
+	var b strings.Builder
+	if c.Short != "" {
+		b.WriteString(c.Name)
+		b.WriteString(" — ")
+		b.WriteString(c.Short)
+		b.WriteString("\n\n")
+	}
+	if flags := c.AllFlags(); len(flags) > 0 {
+		b.WriteString("Flags:\n")
+		for _, f := range flags {
+			b.WriteString("  --")
+			b.WriteString(f.Name)
+			if f.Short != "" {
+				b.WriteString(", -")
+				b.WriteString(f.Short)
+			}
+			if f.TakesArg {
+				b.WriteString(" <value>")
+			}
+			if f.Description != "" {
+				b.WriteString("    ")
+				b.WriteString(f.Description)
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+	if len(c.Subcommands) > 0 {
+		b.WriteString("Subcommands:\n")
+		for _, s := range c.Subcommands {
+			b.WriteString("  ")
+			b.WriteString(s.Name)
+			if s.Short != "" {
+				b.WriteString("    ")
+				b.WriteString(s.Short)
+			}
+			b.WriteString("\n")
+		}
+	}
+	_, err := io.WriteString(w, b.String())
+	return err
+}

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -1,0 +1,228 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestAllFlagsOrdersPersistentBeforeFlags(t *testing.T) {
+	c := Command{
+		Persistent: []FlagDef{{Name: "profile"}, {Name: "port"}},
+		Flags:      []FlagDef{{Name: "verbose"}},
+	}
+	got := c.AllFlags()
+	want := []string{"profile", "port", "verbose"}
+	if len(got) != len(want) {
+		t.Fatalf("AllFlags len=%d, want %d", len(got), len(want))
+	}
+	for i, name := range want {
+		if got[i].Name != name {
+			t.Errorf("AllFlags[%d].Name = %q, want %q", i, got[i].Name, name)
+		}
+	}
+}
+
+func TestKnownFlagsCoversPersistentAndLocal(t *testing.T) {
+	c := Command{
+		Persistent: []FlagDef{{Name: "profile"}},
+		Flags:      []FlagDef{{Name: "verbose"}, {Name: "port", TakesArg: true}},
+	}
+	known := c.KnownFlags()
+	for _, want := range []string{"--profile", "--verbose", "--port"} {
+		if !known[want] {
+			t.Errorf("KnownFlags missing %q", want)
+		}
+	}
+	if known["--unknown"] {
+		t.Errorf("KnownFlags should not contain --unknown")
+	}
+}
+
+func TestToCompletionDropsResolutionMetadata(t *testing.T) {
+	f := FlagDef{
+		Name:        "profile",
+		Short:       "p",
+		Description: "Databricks profile",
+		TakesArg:    true,
+		Completer:   "__databricks_profiles",
+		StateKey:    "profile",
+		EnvVar:      "DATABRICKS_CONFIG_PROFILE",
+		MDMKey:      "databricksProfile",
+		Default:     "DEFAULT",
+	}
+	got := f.ToCompletion()
+	if got.Name != "profile" || got.Short != "p" || got.Description != "Databricks profile" ||
+		!got.TakesArg || got.Completer != "__databricks_profiles" {
+		t.Errorf("ToCompletion lost completion-relevant fields: %+v", got)
+	}
+}
+
+func TestRenderUsesLongVerbatimWithVarSubstitution(t *testing.T) {
+	c := Command{Long: "version={{Version}}\n"}
+	var buf bytes.Buffer
+	if err := Render(&buf, c, map[string]string{"Version": "1.2.3"}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if buf.String() != "version=1.2.3\n" {
+		t.Errorf("Render output = %q, want %q", buf.String(), "version=1.2.3\n")
+	}
+}
+
+// --- Parse tests ---
+
+func TestParse_LongFlagSpaceForm(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "profile", TakesArg: true}}}
+	r, err := c.Parse([]string{"--profile", "prod"})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if r.Strings["profile"] != "prod" || !r.Set["profile"] {
+		t.Errorf("expected profile=prod set=true, got %+v", r)
+	}
+}
+
+func TestParse_LongFlagEqualForm(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "profile", TakesArg: true}}}
+	r, _ := c.Parse([]string{"--profile=prod"})
+	if r.Strings["profile"] != "prod" || !r.Set["profile"] {
+		t.Errorf("expected profile=prod set=true, got %+v", r)
+	}
+}
+
+func TestParse_BoolFlag(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "verbose"}}}
+	r, _ := c.Parse([]string{"--verbose"})
+	if !r.Bools["verbose"] || !r.Set["verbose"] {
+		t.Errorf("expected verbose=true set=true, got %+v", r)
+	}
+}
+
+func TestParse_BoolFlagExplicitFalse(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "daemon"}}}
+	for _, v := range []string{"--daemon=false", "--daemon=0", "--daemon=no", "--daemon=NO"} {
+		r, _ := c.Parse([]string{v})
+		if r.Bools["daemon"] {
+			t.Errorf("%q: expected daemon=false, got true", v)
+		}
+		if !r.Set["daemon"] {
+			t.Errorf("%q: expected set=true even on falsy explicit", v)
+		}
+	}
+}
+
+func TestParse_ShortAlias(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "verbose", Short: "v"}, {Name: "help", Short: "h"}}}
+	r, _ := c.Parse([]string{"-v", "-h"})
+	if !r.Bools["verbose"] || !r.Bools["help"] {
+		t.Errorf("expected -v→verbose, -h→help, got %+v", r)
+	}
+}
+
+func TestParse_PersistentInherited(t *testing.T) {
+	c := Command{
+		Persistent: []FlagDef{{Name: "profile", TakesArg: true}},
+		Flags:      []FlagDef{{Name: "log-file", TakesArg: true}},
+	}
+	r, _ := c.Parse([]string{"--profile", "p", "--log-file", "/tmp/x"})
+	if r.Strings["profile"] != "p" || r.Strings["log-file"] != "/tmp/x" {
+		t.Errorf("persistent + local flag: got %+v", r)
+	}
+}
+
+func TestParse_UnknownLongFlagToPositional(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "profile", TakesArg: true}}}
+	r, _ := c.Parse([]string{"--unknown", "--profile", "x", "--also-unknown=val"})
+	if r.Strings["profile"] != "x" {
+		t.Errorf("known flag still consumed: got %+v", r)
+	}
+	want := []string{"--unknown", "--also-unknown=val"}
+	if len(r.Positional) != len(want) || r.Positional[0] != want[0] || r.Positional[1] != want[1] {
+		t.Errorf("Positional = %v, want %v", r.Positional, want)
+	}
+}
+
+func TestParse_DoubleDashTerminator(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "profile", TakesArg: true}}}
+	r, _ := c.Parse([]string{"--profile", "p", "--", "--help", "rest"})
+	if r.Strings["profile"] != "p" {
+		t.Errorf("--profile should be consumed before --, got %+v", r)
+	}
+	want := []string{"--help", "rest"}
+	if len(r.Positional) != len(want) || r.Positional[0] != want[0] || r.Positional[1] != want[1] {
+		t.Errorf("Positional after --: %v, want %v", r.Positional, want)
+	}
+}
+
+func TestParse_PositionalAction(t *testing.T) {
+	c := Command{Flags: []FlagDef{{Name: "profile", TakesArg: true}}}
+	r, _ := c.Parse([]string{"generate-config", "--profile", "p"})
+	if len(r.Positional) != 1 || r.Positional[0] != "generate-config" {
+		t.Errorf("Positional: got %v, want [generate-config]", r.Positional)
+	}
+	if r.Strings["profile"] != "p" {
+		t.Errorf("flag after positional should still parse, got %+v", r)
+	}
+}
+
+func TestParse_BareTakesArgAtEnd(t *testing.T) {
+	// Mirrors the hand-rolled scanner tolerance: bare `--profile` with no
+	// following token leaves the value empty rather than erroring.
+	c := Command{Flags: []FlagDef{{Name: "profile", TakesArg: true}}}
+	r, _ := c.Parse([]string{"--profile"})
+	if r.Strings["profile"] != "" || !r.Set["profile"] {
+		t.Errorf("bare --profile at end: got %+v, want empty string + Set=true", r)
+	}
+}
+
+func TestParse_SetTrueGuardsStatePersistence(t *testing.T) {
+	// The sentinel-guard contract: Set must be true ONLY when the user
+	// explicitly provided the flag, never when the flag was absent. Drives
+	// the parity between historical *Set bools and the new ParseResult.Set
+	// map.
+	c := Command{Flags: []FlagDef{{Name: "otel-metrics-table", TakesArg: true}}}
+	r, _ := c.Parse([]string{})
+	if r.Set["otel-metrics-table"] {
+		t.Errorf("Set should be false when flag absent, got %+v", r)
+	}
+	r2, _ := c.Parse([]string{"--otel-metrics-table=cat.s.t"})
+	if !r2.Set["otel-metrics-table"] || r2.Strings["otel-metrics-table"] != "cat.s.t" {
+		t.Errorf("Set should be true with value, got %+v", r2)
+	}
+}
+
+func TestParse_NestedSubcommandFlagsOnDeepest(t *testing.T) {
+	// install command inherits --profile from parent serve via Persistent.
+	// (The runner is responsible for walking the chain; Parse itself sees a
+	// flat AllFlags.) This test pins that AllFlags on a child with declared
+	// Persistent ++ Flags accepts both.
+	install := Command{
+		Persistent: []FlagDef{{Name: "profile", TakesArg: true}},
+		Flags:      []FlagDef{{Name: "skip-auth-check"}},
+	}
+	r, _ := install.Parse([]string{"--profile", "prod", "--skip-auth-check"})
+	if r.Strings["profile"] != "prod" || !r.Bools["skip-auth-check"] {
+		t.Errorf("nested-flag parse: got %+v", r)
+	}
+}
+
+func TestRenderFallsBackToProgrammaticWhenLongIsEmpty(t *testing.T) {
+	c := Command{
+		Name:  "demo",
+		Short: "Example",
+		Flags: []FlagDef{{Name: "verbose", Description: "Enable debug"}},
+		Subcommands: []Command{
+			{Name: "child", Short: "A child"},
+		},
+	}
+	var buf bytes.Buffer
+	if err := Render(&buf, c, nil); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"demo — Example", "--verbose", "Enable debug", "child", "A child"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Render fallback missing %q in:\n%s", want, out)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/IceRhymers/databricks-claude/pkg/proxy"
 	"github.com/IceRhymers/databricks-claude/pkg/refcount"
 	"github.com/IceRhymers/databricks-claude/pkg/updater"
+	"github.com/IceRhymers/databricks-opencode/internal/cmd"
 	"github.com/IceRhymers/databricks-opencode/pkg/jsonconfig"
 )
 
@@ -36,6 +37,15 @@ func main() {
 	if len(os.Args) >= 2 && os.Args[1] == "completion" {
 		completion.Run(os.Args[2:], flagDefs, "databricks-opencode")
 		os.Exit(0)
+	}
+
+	// `config` subcommand — persistent-config editor. Today this is just
+	// `config show` (the lifted --print-env diagnostic); future sub-issues
+	// may grow this tree. Routed before parseArgs so positional dispatch
+	// doesn't have to fight with the transparent-passthrough behaviour.
+	if len(os.Args) >= 2 && os.Args[1] == "config" {
+		runConfigCommand(os.Args[2:])
+		return
 	}
 
 	// update — force-check for a newer release and print instructions.
@@ -74,7 +84,6 @@ func main() {
 	verbose := a.Verbose
 	version := a.Version
 	showHelp := a.ShowHelp
-	printEnv := a.PrintEnv
 	model := a.Model
 	upstream := a.Upstream
 	logFile := a.LogFile
@@ -242,8 +251,7 @@ func main() {
 
 	// --- Seed token cache ---
 	tp := NewTokenProvider("", profile)
-	initialToken, err := tp.Token(context.Background())
-	if err != nil {
+	if _, err := tp.Token(context.Background()); err != nil {
 		log.Fatalf("databricks-opencode: failed to fetch initial token: %v", err)
 	}
 
@@ -259,12 +267,6 @@ func main() {
 		gatewayURL = ConstructGatewayURL(host)
 	}
 	log.Printf("databricks-opencode: gateway URL: %s", gatewayURL)
-
-	// --- Print env and exit if requested ---
-	if printEnv {
-		handlePrintEnv(host, gatewayURL, initialToken, profile, model)
-		os.Exit(0)
-	}
 
 	// Verify opencode is on PATH before starting proxy (skip in headless mode).
 	if !headless {
@@ -414,7 +416,6 @@ type Args struct {
 	Verbose            bool
 	Version            bool
 	ShowHelp           bool
-	PrintEnv           bool
 	Model              string
 	Upstream           string
 	LogFile            string
@@ -534,8 +535,6 @@ func parseArgs(args []string) (*Args, error) {
 					a.Version = true
 				case "--help":
 					a.ShowHelp = true
-				case "--print-env":
-					a.PrintEnv = true
 				case "--headless":
 					a.Headless = true
 				case "--idle-timeout":
@@ -559,6 +558,8 @@ func parseArgs(args []string) (*Args, error) {
 					a.HeadlessEnsureFlag = true
 				case "--no-update-check":
 					a.NoUpdateCheck = true
+				default:
+					return nil, fmt.Errorf("internal: %s is a known flag but parseArgs has no case for it", name)
 				}
 				i++
 				continue
@@ -594,42 +595,10 @@ func runHeadless(proxyURL string, ln net.Listener, isOwner bool, doneCh chan str
 }
 
 // handleHelp prints the databricks-opencode help section, then execs opencode --help.
+// The first half is rendered from the rootCommand registry (commands.go) so
+// the help body, flag set, and completion scripts share one source of truth.
 func handleHelp(upstreamBinary string) {
-	fmt.Printf(`databricks-opencode v%s — Databricks AI Gateway wrapper for OpenCode CLI
-
-Patches the opencode config (opencode.json) and runs a local proxy so the OpenCode CLI
-authenticates through a Databricks AI Gateway endpoint with live token refresh.
-
-Usage:
-  databricks-opencode [databricks-opencode flags] [opencode flags] [opencode args]
-
-Databricks-OpenCode Flags:
-  --profile string      Databricks CLI profile (saved for future sessions; default: env or "DEFAULT")
-  --upstream string     Override the AI Gateway URL (default: auto-discovered)
-  --model string        Model to use (default: "databricks-claude-opus-4-7")
-  --print-env           Print resolved configuration and exit (token redacted)
-  --verbose, -v         Enable debug logging to stderr
-  --log-file string     Write debug logs to a file (combinable with --verbose)
-  --proxy-api-key string    Require this API key on all proxy requests (default: disabled)
-  --tls-cert string         Path to TLS certificate file (requires --tls-key)
-  --tls-key string          Path to TLS private key file (requires --tls-cert)
-  --port int                Local proxy port (default: 49156, saved for future sessions)
-  --headless            Start proxy without launching opencode (for IDE extensions)
-  --idle-timeout duration   Idle timeout for headless mode (default 30m, 0 disables; use e.g. 30s, 5m, 1h)
-  --install-hooks       Install opencode plugin hooks for automatic proxy lifecycle
-  --uninstall-hooks     Remove databricks-opencode plugin from opencode config
-  --headless-ensure     Start proxy if not running (called by opencode plugin at init)
-  --no-update-check            Skip the automatic update check on startup
-  --version             Print version and exit
-  --help, -h            Show this help message
-
-Subcommands:
-  completion <shell>           Generate shell completions (bash, zsh, fish)
-  update                       Check for a newer release and print upgrade instructions
-
-────────────────────────────────────────────────────────────────────────────────
-OpenCode CLI Options:
-`, Version)
+	_ = cmd.Render(os.Stdout, rootCommand, map[string]string{"Version": Version})
 
 	opencodeBin := upstreamBinary
 	if opencodeBin == "" {

--- a/main.go
+++ b/main.go
@@ -57,6 +57,16 @@ func main() {
 		return
 	}
 
+	// `serve` subcommand — start the proxy without launching opencode.
+	// Replaces the removed --headless / --idle-timeout root flags. Routed
+	// before parseArgs so positional dispatch doesn't fight the
+	// transparent-passthrough behaviour. The dispatcher in serve_cmd.go
+	// parses its own flags then calls runOpencode with Headless=true.
+	if len(os.Args) >= 2 && os.Args[1] == "serve" {
+		runServeCommand(os.Args[2:])
+		return
+	}
+
 	// update — force-check for a newer release and print instructions.
 	if len(os.Args) >= 2 && os.Args[1] == "update" {
 		if os.Getenv("DATABRICKS_NO_UPDATE_CHECK") == "1" {
@@ -90,6 +100,23 @@ func main() {
 		os.Exit(1)
 	}
 
+	runOpencode(a)
+}
+
+// runOpencode is the post-parse body of the wrapper-mode flow. Lifted out of
+// main() in #84 so the `serve` dispatcher can synthesise an *Args (with
+// Headless=true and IdleTimeout populated from `serve --idle-timeout`) and
+// reuse the same proxy-startup + config-patch + opencode-launch logic.
+//
+// Wrapper invocation: main() builds *a from os.Args via parseArgs, leaving
+// Headless=false and IdleTimeout=0 — runOpencode then launches opencode as a
+// child after starting the proxy. Serve invocation: serve_cmd.runServeCommand
+// builds *a from the post-`serve` arg list, sets Headless=true plus the
+// resolved IdleTimeout, and runOpencode skips the opencode child launch and
+// blocks on the lifecycle wrapper instead. The two paths share everything
+// else (port binding, EnsureConfig, refcount, takeover, etc.) so the AC
+// "byte-identical behaviour to --headless" holds by construction.
+func runOpencode(a *Args) {
 	verbose := a.Verbose
 	version := a.Version
 	showHelp := a.ShowHelp
@@ -391,6 +418,13 @@ func main() {
 }
 
 // Args holds all parsed databricks-opencode flags plus the residual opencode args.
+//
+// Headless and IdleTimeout are NOT populated by parseArgs as of #84 — the
+// `--headless` / `--idle-timeout` root flags were removed and replaced by the
+// `serve` subcommand. Both fields remain on the struct because runOpencode
+// reads them: the serve dispatcher (serve_cmd.go) synthesises an Args with
+// Headless=true and IdleTimeout populated from `serve --idle-timeout` before
+// calling runOpencode, so the post-parse logic stays single-sourced.
 type Args struct {
 	Verbose       bool
 	Version       bool
@@ -403,17 +437,23 @@ type Args struct {
 	TLSCert       string
 	TLSKey        string
 	Port          int
-	Headless      bool
-	IdleTimeout   time.Duration
+	Headless      bool          // populated only by the `serve` dispatcher
+	IdleTimeout   time.Duration // populated only by the `serve` dispatcher
 	NoUpdateCheck bool
 	OpencodeArgs  []string
 }
 
 // parseArgs separates databricks-opencode flags from opencode flags.
+//
+// As of #84, --headless and --idle-timeout are NOT recognised at the root —
+// they live under the `serve` subcommand. parseArgs leaves Args.Headless
+// false and Args.IdleTimeout zero; the `serve` dispatcher in serve_cmd.go
+// populates them when invoking runOpencode. Anything that looks like
+// --headless / --idle-timeout at the root falls through to opencode (the
+// transparent-passthrough behaviour the wrapper applies to all unknown
+// flags).
 func parseArgs(args []string) (*Args, error) {
-	a := &Args{
-		IdleTimeout: 30 * time.Minute, // default
-	}
+	a := &Args{}
 
 	// knownFlags is defined at package level in completion_flags.go,
 	// derived from flagDefs so completions and parsing stay in sync.
@@ -511,21 +551,6 @@ func parseArgs(args []string) (*Args, error) {
 					a.Version = true
 				case "--help":
 					a.ShowHelp = true
-				case "--headless":
-					a.Headless = true
-				case "--idle-timeout":
-					raw := value
-					if raw == "" && i+1 < len(args) {
-						i++
-						raw = args[i]
-					}
-					if raw != "" {
-						d, perr := time.ParseDuration(raw)
-						if perr != nil {
-							return nil, fmt.Errorf("--idle-timeout: %q is not a valid duration (use e.g. 30s, 5m, 1h)", raw)
-						}
-						a.IdleTimeout = d
-					}
 				case "--no-update-check":
 					a.NoUpdateCheck = true
 				default:

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 	// completion <shell> — must be the very first check, before any flag parsing,
 	// auth, or state loading. Safe to call in the Homebrew install sandbox.
 	if len(os.Args) >= 2 && os.Args[1] == "completion" {
-		completion.Run(os.Args[2:], flagDefs, "databricks-opencode")
+		completion.Run(os.Args[2:], flagDefs, "databricks-opencode", knownSubcommands...)
 		os.Exit(0)
 	}
 
@@ -45,6 +45,15 @@ func main() {
 	// doesn't have to fight with the transparent-passthrough behaviour.
 	if len(os.Args) >= 2 && os.Args[1] == "config" {
 		runConfigCommand(os.Args[2:])
+		return
+	}
+
+	// `hooks` subcommand — opencode plugin lifecycle. Replaces the removed
+	// --install-hooks / --uninstall-hooks / --headless-ensure root flags.
+	// Routed before parseArgs so positional dispatch doesn't have to fight
+	// with the transparent-passthrough behaviour.
+	if len(os.Args) >= 2 && os.Args[1] == "hooks" {
+		runHooksCommand(os.Args[2:])
 		return
 	}
 
@@ -94,9 +103,6 @@ func main() {
 	portFlag := a.Port
 	headless := a.Headless
 	idleTimeout := a.IdleTimeout
-	installHooksFlag := a.InstallHooksFlag
-	uninstallHooksFlag := a.UninstallHooksFlag
-	headlessEnsureFlag := a.HeadlessEnsureFlag
 	noUpdateCheck := a.NoUpdateCheck
 	opencodeArgs := a.OpencodeArgs
 
@@ -107,33 +113,6 @@ func main() {
 
 	if version {
 		fmt.Printf("databricks-opencode %s\n", Version)
-		os.Exit(0)
-	}
-
-	// --- Hook lifecycle commands (handled before auth/config setup) ---
-	if installHooksFlag || uninstallHooksFlag {
-		if installHooksFlag {
-			if err := installHooks(); err != nil {
-				log.Fatalf("databricks-opencode: --install-hooks: %v", err)
-			}
-			hookDir, _ := opencodeConfigDir()
-			fmt.Fprintf(os.Stderr, "databricks-opencode: hooks installed — opencode plugin written to %s\n", filepath.Join(hookDir, "plugins", "databricks-proxy", "index.js"))
-		} else {
-			if err := uninstallHooks(); err != nil {
-				log.Fatalf("databricks-opencode: --uninstall-hooks: %v", err)
-			}
-			fmt.Fprintln(os.Stderr, "databricks-opencode: hooks removed from opencode config")
-		}
-		os.Exit(0)
-	}
-
-	// --- Headless hook command (called by the opencode plugin, not by end users) ---
-	if headlessEnsureFlag {
-		state := loadState()
-		port := resolvePort(0, state)
-		if err := headlessEnsure(port); err != nil {
-			log.Fatalf("databricks-opencode: headless ensure failed: %v", err)
-		}
 		os.Exit(0)
 	}
 
@@ -413,24 +392,21 @@ func main() {
 
 // Args holds all parsed databricks-opencode flags plus the residual opencode args.
 type Args struct {
-	Verbose            bool
-	Version            bool
-	ShowHelp           bool
-	Model              string
-	Upstream           string
-	LogFile            string
-	Profile            string
-	ProxyAPIKey        string
-	TLSCert            string
-	TLSKey             string
-	Port               int
-	Headless           bool
-	IdleTimeout        time.Duration
-	InstallHooksFlag   bool
-	UninstallHooksFlag bool
-	HeadlessEnsureFlag bool
-	NoUpdateCheck      bool
-	OpencodeArgs       []string
+	Verbose       bool
+	Version       bool
+	ShowHelp      bool
+	Model         string
+	Upstream      string
+	LogFile       string
+	Profile       string
+	ProxyAPIKey   string
+	TLSCert       string
+	TLSKey        string
+	Port          int
+	Headless      bool
+	IdleTimeout   time.Duration
+	NoUpdateCheck bool
+	OpencodeArgs  []string
 }
 
 // parseArgs separates databricks-opencode flags from opencode flags.
@@ -550,12 +526,6 @@ func parseArgs(args []string) (*Args, error) {
 						}
 						a.IdleTimeout = d
 					}
-				case "--install-hooks":
-					a.InstallHooksFlag = true
-				case "--uninstall-hooks":
-					a.UninstallHooksFlag = true
-				case "--headless-ensure":
-					a.HeadlessEnsureFlag = true
 				case "--no-update-check":
 					a.NoUpdateCheck = true
 				default:

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 )
 
 // --- parseArgs tests ---
@@ -566,10 +565,31 @@ func TestParseArgs_PortEquals(t *testing.T) {
 	}
 }
 
-func TestParseArgs_Headless(t *testing.T) {
+// TestParseArgs_HeadlessRemoved verifies the legacy --headless root flag is
+// no longer recognised by parseArgs (#84 moved it under the `serve`
+// subcommand). Behaviour: parseArgs forwards unknown flags to opencode, so
+// --headless should appear in OpencodeArgs and Args.Headless stays false.
+func TestParseArgs_HeadlessRemoved(t *testing.T) {
 	a := mustParse(t, []string{"--headless"})
-	if !a.Headless {
-		t.Error("expected Headless=true for --headless")
+	if a.Headless {
+		t.Error("Args.Headless must remain false; the flag is no longer parsed at the root")
+	}
+	if len(a.OpencodeArgs) != 1 || a.OpencodeArgs[0] != "--headless" {
+		t.Errorf("--headless should now forward to opencode as unknown, got OpencodeArgs=%v", a.OpencodeArgs)
+	}
+}
+
+// TestParseArgs_IdleTimeoutRemoved verifies --idle-timeout is no longer
+// recognised at the root (#84 moved it under `serve`). It now forwards
+// transparently to opencode like any other unknown flag.
+func TestParseArgs_IdleTimeoutRemoved(t *testing.T) {
+	a := mustParse(t, []string{"--idle-timeout", "30m"})
+	if a.IdleTimeout != 0 {
+		t.Errorf("Args.IdleTimeout must remain 0; the flag is no longer parsed at the root, got %v", a.IdleTimeout)
+	}
+	// Both tokens should pass through to opencode unchanged.
+	if len(a.OpencodeArgs) != 2 || a.OpencodeArgs[0] != "--idle-timeout" || a.OpencodeArgs[1] != "30m" {
+		t.Errorf("--idle-timeout 30m should forward to opencode, got OpencodeArgs=%v", a.OpencodeArgs)
 	}
 }
 
@@ -594,12 +614,52 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	// Note: --print-env removed in #82 (replaced by `config show`); the
 	// hooks lifecycle flags --install-hooks, --uninstall-hooks, and
 	// --headless-ensure removed in #83 (replaced by the `hooks` subcommand
-	// — see TestHandleHelp_HookFlagsRemoved). Neither set is listed here.
-	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--model", "--version", "--help", "--port", "--headless", "--idle-timeout", "--no-update-check"}
+	// — see TestHandleHelp_HookFlagsRemoved). --headless and --idle-timeout
+	// removed in #84 (replaced by the `serve` subcommand — see
+	// TestHandleHelp_HeadlessFlagsRemoved). None of those sets are listed
+	// here.
+	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--model", "--version", "--help", "--port", "--no-update-check"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
 			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)
 		}
+	}
+}
+
+// TestHandleHelp_HeadlessFlagsRemoved verifies the legacy --headless and
+// --idle-timeout root flags no longer appear in the help body (#84
+// replaced them with the `serve` subcommand). The serve-subcommand line
+// itself should mention `--idle-timeout` because the help template lists
+// the new home for the flag, so we only assert the bare-flag forms are
+// absent — the `serve --idle-timeout` callout in the body is fine.
+func TestHandleHelp_HeadlessFlagsRemoved(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp("")
+	})
+	// "--headless" must not appear at all (the new entrypoint is `serve`).
+	if strings.Contains(out, "--headless") {
+		t.Errorf("help output should not mention --headless (replaced by `serve`), got:\n%s", out)
+	}
+	// "--idle-timeout" appears only inside the `serve [--idle-timeout]`
+	// line of the subcommands table; assert it is NOT listed in the
+	// flags table by checking it doesn't appear on a leading-whitespace
+	// flag line of its own (e.g. "  --idle-timeout duration").
+	for _, ghost := range []string{"  --idle-timeout duration", "  --idle-timeout string"} {
+		if strings.Contains(out, ghost) {
+			t.Errorf("help output should not list --idle-timeout as a root flag, got:\n%s", out)
+		}
+	}
+}
+
+// TestHandleHelp_ContainsServeSubcommand verifies the new `serve`
+// subcommand surfaces in the help body so users can discover it as the
+// replacement for `--headless`.
+func TestHandleHelp_ContainsServeSubcommand(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp("")
+	})
+	if !strings.Contains(out, "serve") {
+		t.Errorf("expected help output to mention `serve` subcommand, got:\n%s", out)
 	}
 }
 
@@ -672,58 +732,11 @@ func TestKnownFlagsCoverAllFlagDefs(t *testing.T) {
 	}
 }
 
-// --- --idle-timeout strict parsing tests (issue #72) ---
-
-func TestParseArgs_IdleTimeoutInvalidWord(t *testing.T) {
-	_, err := parseArgs([]string{"--idle-timeout=5min"})
-	if err == nil {
-		t.Fatal("expected error for --idle-timeout=5min, got nil")
-	}
-	if !strings.Contains(err.Error(), "--idle-timeout") {
-		t.Errorf("error should mention --idle-timeout, got: %v", err)
-	}
-}
-
-func TestParseArgs_IdleTimeoutBareNumberRejected(t *testing.T) {
-	// Was previously interpreted as 30 minutes — must now error.
-	_, err := parseArgs([]string{"--idle-timeout=30"})
-	if err == nil {
-		t.Fatal("expected error for bare number --idle-timeout=30, got nil")
-	}
-}
-
-func TestParseArgs_IdleTimeoutValidDurations(t *testing.T) {
-	cases := []struct {
-		raw  string
-		want time.Duration
-	}{
-		{"30s", 30 * time.Second},
-		{"5m", 5 * time.Minute},
-		{"1h", 1 * time.Hour},
-		{"0", 0},
-	}
-	for _, c := range cases {
-		t.Run(c.raw, func(t *testing.T) {
-			a, err := parseArgs([]string{"--idle-timeout=" + c.raw})
-			if err != nil {
-				t.Fatalf("expected no error for --idle-timeout=%s, got %v", c.raw, err)
-			}
-			if a.IdleTimeout != c.want {
-				t.Errorf("--idle-timeout=%s: got %v, want %v", c.raw, a.IdleTimeout, c.want)
-			}
-		})
-	}
-}
-
-func TestParseArgs_IdleTimeoutSpaceSeparated(t *testing.T) {
-	a, err := parseArgs([]string{"--idle-timeout", "1h"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if a.IdleTimeout != time.Hour {
-		t.Errorf("expected 1h, got %v", a.IdleTimeout)
-	}
-}
+// --idle-timeout strict-parsing tests (issue #72, PR #76) lived here while the
+// flag was a root flag. #84 lifted --idle-timeout under the `serve`
+// subcommand and dropped the root parser's case for it; the bare-number-is-
+// minutes grammar plus the "valid duration" cases are exercised against the
+// new parseServeIdleTimeout helper in serve_cmd_test.go.
 
 // --- Tree ↔ parser parity tests (#82) ---
 //

--- a/main_test.go
+++ b/main_test.go
@@ -591,11 +591,41 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp("")
 	})
-	// Note: --print-env removed in #82 (replaced by `config show`); not in this list.
-	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--model", "--version", "--help", "--port", "--headless", "--idle-timeout", "--install-hooks", "--uninstall-hooks", "--headless-ensure", "--no-update-check"}
+	// Note: --print-env removed in #82 (replaced by `config show`); the
+	// hooks lifecycle flags --install-hooks, --uninstall-hooks, and
+	// --headless-ensure removed in #83 (replaced by the `hooks` subcommand
+	// — see TestHandleHelp_HookFlagsRemoved). Neither set is listed here.
+	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--model", "--version", "--help", "--port", "--headless", "--idle-timeout", "--no-update-check"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
 			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)
+		}
+	}
+}
+
+// TestHandleHelp_HookFlagsRemoved verifies that --install-hooks /
+// --uninstall-hooks / --headless-ensure no longer appear in the help body
+// (#83 replaced them with the `hooks` subcommand).
+func TestHandleHelp_HookFlagsRemoved(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp("")
+	})
+	for _, removed := range []string{"--install-hooks", "--uninstall-hooks", "--headless-ensure"} {
+		if strings.Contains(out, removed) {
+			t.Errorf("help output should not mention %q (replaced by `hooks` subcommand), got:\n%s", removed, out)
+		}
+	}
+}
+
+// TestHandleHelp_ContainsHooksSubcommand verifies that the new `hooks`
+// subcommand surfaces in the help body so users can discover it.
+func TestHandleHelp_ContainsHooksSubcommand(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp("")
+	})
+	for _, want := range []string{"hooks install", "hooks uninstall", "hooks session-start"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected help output to mention %q, got:\n%s", want, out)
 		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -28,7 +28,7 @@ func TestParseArgs_HelpLong(t *testing.T) {
 	if !a.ShowHelp {
 		t.Error("expected ShowHelp=true for --help")
 	}
-	if a.Verbose || a.Version || a.PrintEnv || a.Model != "" || a.Upstream != "" || a.LogFile != "" || a.Profile != "" || len(a.OpencodeArgs) != 0 {
+	if a.Verbose || a.Version || a.Model != "" || a.Upstream != "" || a.LogFile != "" || a.Profile != "" || len(a.OpencodeArgs) != 0 {
 		t.Error("unexpected non-default values alongside --help")
 	}
 }
@@ -40,10 +40,13 @@ func TestParseArgs_HelpShort(t *testing.T) {
 	}
 }
 
-func TestParseArgs_PrintEnv(t *testing.T) {
+// TestParseArgs_PrintEnvRemoved verifies that --print-env is no longer a
+// known flag (replaced by `config show` in #82). Behavior: parseArgs forwards
+// unknown flags to opencode, so --print-env should appear in OpencodeArgs.
+func TestParseArgs_PrintEnvRemoved(t *testing.T) {
 	a := mustParse(t, []string{"--print-env"})
-	if !a.PrintEnv {
-		t.Error("expected PrintEnv=true for --print-env")
+	if len(a.OpencodeArgs) != 1 || a.OpencodeArgs[0] != "--print-env" {
+		t.Errorf("--print-env should now forward to opencode as unknown, got OpencodeArgs=%v", a.OpencodeArgs)
 	}
 }
 
@@ -119,7 +122,7 @@ func TestParseArgs_UnknownFlagPassthrough(t *testing.T) {
 
 func TestParseArgs_EmptyArgs(t *testing.T) {
 	a := mustParse(t, []string{})
-	if a.Verbose || a.Version || a.ShowHelp || a.PrintEnv {
+	if a.Verbose || a.Version || a.ShowHelp {
 		t.Error("expected all bool flags false for empty args")
 	}
 	if a.Model != "" {
@@ -175,7 +178,6 @@ func TestParseArgs_Table(t *testing.T) {
 		verbose     bool
 		version     bool
 		showHelp    bool
-		printEnv    bool
 		model       string
 		upstream    string
 		logFile     string
@@ -199,9 +201,9 @@ func TestParseArgs_Table(t *testing.T) {
 			want: result{showHelp: true},
 		},
 		{
-			name: "--print-env sets printEnv",
+			name: "--print-env removed; forwarded as unknown",
 			args: []string{"--print-env"},
-			want: result{printEnv: true},
+			want: result{opencodeLen: 1},
 		},
 		{
 			name: "--version sets version",
@@ -277,9 +279,6 @@ func TestParseArgs_Table(t *testing.T) {
 			}
 			if a.ShowHelp != tc.want.showHelp {
 				t.Errorf("showHelp: got %v, want %v", a.ShowHelp, tc.want.showHelp)
-			}
-			if a.PrintEnv != tc.want.printEnv {
-				t.Errorf("printEnv: got %v, want %v", a.PrintEnv, tc.want.printEnv)
 			}
 			if a.Model != tc.want.model {
 				t.Errorf("model: got %q, want %q", a.Model, tc.want.model)
@@ -429,12 +428,25 @@ func TestHandleHelp_ContainsDatabricksOpencode(t *testing.T) {
 	}
 }
 
-func TestHandleHelp_ContainsPrintEnvFlag(t *testing.T) {
+// TestHandleHelp_PrintEnvRemoved verifies that --print-env no longer
+// appears in the help body (#82 replaced it with `config show`).
+func TestHandleHelp_PrintEnvRemoved(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp("")
 	})
-	if !strings.Contains(out, "--print-env") {
-		t.Errorf("expected help output to contain '--print-env', got:\n%s", out)
+	if strings.Contains(out, "--print-env") {
+		t.Errorf("help output should not mention --print-env (replaced by 'config show'), got:\n%s", out)
+	}
+}
+
+// TestHandleHelp_ContainsConfigSubcommand verifies that the new `config`
+// subcommand surfaces in the help body so users can discover `config show`.
+func TestHandleHelp_ContainsConfigSubcommand(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp("")
+	})
+	if !strings.Contains(out, "config show") {
+		t.Errorf("expected help output to mention 'config show', got:\n%s", out)
 	}
 }
 
@@ -579,6 +591,7 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp("")
 	})
+	// Note: --print-env removed in #82 (replaced by `config show`); not in this list.
 	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--model", "--version", "--help", "--port", "--headless", "--idle-timeout", "--install-hooks", "--uninstall-hooks", "--headless-ensure", "--no-update-check"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
@@ -679,5 +692,110 @@ func TestParseArgs_IdleTimeoutSpaceSeparated(t *testing.T) {
 	}
 	if a.IdleTimeout != time.Hour {
 		t.Errorf("expected 1h, got %v", a.IdleTimeout)
+	}
+}
+
+// --- Tree ↔ parser parity tests (#82) ---
+//
+// The command-tree registry in commands.go is the single source of truth for
+// the root flag set. flagDefs and knownFlags derive from it. parseArgs
+// individually handles each flag in a switch. These two tests pin the
+// bidirectional invariant: every flag declared in the tree is recognised by
+// parseArgs (no silent drops), and every flag parseArgs handles is declared
+// in the tree (no parse-only ghost flags).
+//
+// Bidirectional verification was performed during #82: temporarily deleting a
+// flag from rootCommand causes TestRootTreeFlagsAreParseRecognised to fail
+// loudly, confirming the test catches drift in either direction.
+
+// TestRootTreeFlagsAreParseRecognised exercises every flag declared in
+// rootCommand (Persistent + Flags) and verifies parseArgs accepts it without
+// erroring. A flag added to the tree but missing a switch case in parseArgs
+// will hit the default arm and return the "internal: …" error this test
+// asserts against.
+func TestRootTreeFlagsAreParseRecognised(t *testing.T) {
+	for _, f := range rootCommand.AllFlags() {
+		t.Run(f.Name, func(t *testing.T) {
+			args := []string{"--" + f.Name}
+			if f.TakesArg {
+				// Provide a placeholder value; for --idle-timeout it must
+				// parse as a duration so the post-switch validator passes.
+				switch f.Name {
+				case "idle-timeout":
+					args = append(args, "30m")
+				case "port":
+					args = append(args, "12345")
+				default:
+					args = append(args, "x")
+				}
+			}
+			if _, err := parseArgs(args); err != nil {
+				t.Errorf("parseArgs(%v) errored: %v — flag declared in rootCommand but unhandled in parseArgs", args, err)
+			}
+		})
+	}
+}
+
+// TestParseArgsCasesAreDeclaredInRootTree is the reverse parity: every flag
+// in knownFlags must be declared on rootCommand. Since knownFlags is now
+// derived from rootCommand.KnownFlags(), this test is structurally
+// equivalent to a sanity check on the derivation, but it documents the
+// contract explicitly so a future refactor that hand-rolls knownFlags would
+// fail loudly.
+func TestParseArgsCasesAreDeclaredInRootTree(t *testing.T) {
+	declared := map[string]bool{}
+	for _, f := range rootCommand.AllFlags() {
+		declared["--"+f.Name] = true
+	}
+	for k := range knownFlags {
+		if !declared[k] {
+			t.Errorf("knownFlags has %q but rootCommand has no matching FlagDef — declare it in commands.go", k)
+		}
+	}
+}
+
+// TestConfigShowMatchesLegacyPrintEnv verifies that the new config-show
+// dispatch produces the same output shape as the removed --print-env root
+// flag. We exercise handlePrintEnv directly with the same inputs both code
+// paths feed it; runConfigShow itself requires `databricks` on PATH and
+// valid auth, which CI may not have. This test pins the shared output
+// contract so byte-equivalence smoke tests at the binary level (run during
+// PR verification) have a unit-level companion.
+func TestConfigShowMatchesLegacyPrintEnv(t *testing.T) {
+	host := "https://dbc.example.com"
+	gateway := "https://dbc.example.com/ai-gateway/anthropic"
+	token := "dapi-secret"
+	profile := "DEFAULT"
+	model := "databricks-claude-opus-4-7"
+
+	out := captureStdout(func() {
+		handlePrintEnv(host, gateway, token, profile, model)
+	})
+
+	// Required keys present (the legacy --print-env contract).
+	for _, want := range []string{"Profile:", "Model:", "DATABRICKS_HOST:", "ANTHROPIC_BASE_URL:", "Auth Token:", "OpenCode binary:", host, gateway, profile, model} {
+		if !strings.Contains(out, want) {
+			t.Errorf("config show output missing %q (legacy --print-env contract):\n%s", want, out)
+		}
+	}
+	// Token must be redacted regardless of input shape.
+	if strings.Contains(out, token) {
+		t.Errorf("token %q leaked into config show output:\n%s", token, out)
+	}
+}
+
+// TestConfigShowSubcommandKnownFlags verifies the `show` subcommand's tree
+// declares the expected flags so its own Parse call (in runConfigShow)
+// recognises --profile / --port / --help.
+func TestConfigShowSubcommandKnownFlags(t *testing.T) {
+	show := configCommand.Subcommand("show")
+	if show == nil {
+		t.Fatal("config command tree missing 'show' subcommand")
+	}
+	known := show.KnownFlags()
+	for _, want := range []string{"--profile", "--port", "--help"} {
+		if !known[want] {
+			t.Errorf("config show missing %q in its known-flag set", want)
+		}
 	}
 }

--- a/serve_cmd.go
+++ b/serve_cmd.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/IceRhymers/databricks-opencode/internal/cmd"
+)
+
+// runServeCommand implements `databricks-opencode serve ...`. args is
+// everything after the literal "serve" token. Replaces the removed
+// --headless / --idle-timeout root flags with a discoverable subcommand
+// (issue #84). Mirrors databricks-claude #174 with the same deliberately
+// smaller scope as databricks-codex #89: no daemon mode and no
+// install/uninstall/status — `serve` is the session-scoped lifecycle the
+// removed --headless flag drove, nothing more.
+//
+// The dispatcher parses `serve`-local flags via the tree, synthesises an
+// *Args with Headless=true plus the resolved IdleTimeout, and then forwards
+// to runOpencode — which is the lifted post-parseArgs body of main(). That
+// shared call site is what backs the AC "byte-identical behaviour to
+// `databricks-opencode --headless`": both legacy --headless and the new
+// `serve` codepath converge on the same proxy startup, EnsureConfig patch,
+// and lifecycle wrapper, so the hooks-invoked plugin path (`hooks
+// session-start` → `headless.Ensure` → spawned `<wrapper> serve`) is
+// indistinguishable from the pre-#84 behaviour.
+func runServeCommand(args []string) {
+	r, _ := serveCommand.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, serveCommand, nil)
+		os.Exit(0)
+	}
+
+	// Reject sub-subcommand-like positionals so a typo like `serve foo`
+	// doesn't silently boot the proxy. install/uninstall/status are
+	// DEFERRED for opencode (per issue #84) — surfacing them as "unknown"
+	// here keeps the error story honest and matches the hooks dispatcher's
+	// convention.
+	for _, p := range r.Positional {
+		fmt.Fprintf(os.Stderr, "databricks-opencode: serve: unknown argument %q\n\n", p)
+		_ = cmd.Render(os.Stderr, serveCommand, nil)
+		os.Exit(1)
+	}
+
+	idle, err := parseServeIdleTimeout(r.Strings["idle-timeout"], r.Set["idle-timeout"])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "databricks-opencode: serve: %v\n", err)
+		os.Exit(1)
+	}
+
+	port := 0
+	if v := r.Strings["port"]; v != "" {
+		port, _ = strconv.Atoi(v)
+	}
+
+	a := &Args{
+		Verbose:       r.Bools["verbose"],
+		Model:         r.Strings["model"],
+		Upstream:      r.Strings["upstream"],
+		LogFile:       r.Strings["log-file"],
+		Profile:       r.Strings["profile"],
+		ProxyAPIKey:   r.Strings["proxy-api-key"],
+		TLSCert:       r.Strings["tls-cert"],
+		TLSKey:        r.Strings["tls-key"],
+		Port:          port,
+		Headless:      true,
+		IdleTimeout:   idle,
+		NoUpdateCheck: r.Bools["no-update-check"],
+	}
+	runOpencode(a)
+}
+
+// defaultServeIdleTimeout is the default idle timeout when `serve` is invoked
+// without --idle-timeout. Matches the pre-#84 root-flag default so the
+// migration is byte-equivalent. Exposed as a package var so tests can pin
+// the constant without re-hardcoding it in expectations.
+var defaultServeIdleTimeout = 30 * time.Minute
+
+// parseServeIdleTimeout parses the --idle-timeout value with the AC #84
+// "bare number = minutes" grammar layered on top of time.ParseDuration:
+//
+//   - empty / unset → defaultServeIdleTimeout (30m)
+//   - bare integer (e.g. "5", "30", "0") → N minutes
+//   - "0" (any duration form parsing to zero) → idle timeout disabled
+//   - any time.Duration string ("30s", "5m", "1h") → that duration
+//   - anything else → error
+//
+// The bare-number convenience deliberately diverges from the pre-#84 strict
+// root-flag parser (PR #76 rejected bare numbers because the root flag's
+// resolution chain made the ambiguity actively dangerous: a user typing
+// `--idle-timeout 30` got a silent reinterpretation that didn't match other
+// duration flags in the wrapper). Under `serve`, the issue spells it out as
+// an AC and there is no overloaded resolution chain to mask the intent —
+// `serve --idle-timeout 5` unambiguously means "five minutes."
+func parseServeIdleTimeout(raw string, present bool) (time.Duration, error) {
+	if !present || raw == "" {
+		return defaultServeIdleTimeout, nil
+	}
+	// Bare integer: interpret as minutes. AC #84.
+	if n, err := strconv.Atoi(raw); err == nil {
+		if n < 0 {
+			return 0, fmt.Errorf("--idle-timeout: %q is negative; use 0 to disable or a positive value", raw)
+		}
+		return time.Duration(n) * time.Minute, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("--idle-timeout: %q is not a valid duration (use e.g. 30s, 5m, 1h, or a bare number for minutes)", raw)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("--idle-timeout: %q is negative; use 0 to disable or a positive value", raw)
+	}
+	return d, nil
+}

--- a/serve_cmd_test.go
+++ b/serve_cmd_test.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// --- #84 serve tree parity tests ---
+//
+// The command-tree registry in commands.go is the single source of truth for
+// the serve subcommand surface. These tests pin the tree shape: the flags
+// the dispatcher (runServeCommand) reads from r.Strings/r.Bools/r.Set are
+// declared on the tree, and the recursive completion walk surfaces `serve`
+// as a position-1 subcommand.
+
+// TestServeCommandTreeParity walks the serve subcommand and asserts the
+// flags the dispatcher routes to (--profile, --port, --upstream, --model,
+// --proxy-api-key, --tls-cert, --tls-key, --log-file, --verbose,
+// --no-update-check, --idle-timeout, --help) are declared on the tree. If
+// the runner reads a flag that isn't declared, completion is silently
+// missing and `cmd.Parse` will route it to Positional (which the
+// dispatcher rejects), so this parity is load-bearing.
+func TestServeCommandTreeParity(t *testing.T) {
+	root := rootCommand.Subcommand("serve")
+	if root == nil {
+		t.Fatal("rootCommand should have a `serve` subcommand declared")
+	}
+	known := root.KnownFlags()
+	want := []string{
+		"--profile", "--port", "--upstream", "--model",
+		"--proxy-api-key", "--tls-cert", "--tls-key",
+		"--log-file", "--verbose", "--no-update-check",
+		"--idle-timeout", "--help",
+	}
+	for _, k := range want {
+		if !known[k] {
+			t.Errorf("serve missing %q in its known-flag set", k)
+		}
+	}
+	// Catch the reverse: any flag declared on the tree must be expected
+	// by this assertion. A stray flag means either the tree gained one
+	// the runner doesn't read OR this test went stale.
+	for k := range known {
+		found := false
+		for _, w := range want {
+			if k == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("serve has unexpected flag %q (update test or remove flag)", k)
+		}
+	}
+}
+
+// TestRootCompletionOffersServeSubcommand asserts `serve` is surfaced in the
+// root command-tree's CompletionSubcommands output so `databricks-opencode
+// <TAB>` offers it as a position-1 completion. Drives AC #84:
+// "shell completion completes `serve <TAB>` and `serve --idle-timeout <TAB>`."
+func TestRootCompletionOffersServeSubcommand(t *testing.T) {
+	for _, sc := range knownSubcommands {
+		if sc.Name != "serve" {
+			continue
+		}
+		// Confirm --idle-timeout is among the completion-flag set so the
+		// recursive shell-completion generator emits it for `serve <TAB>`.
+		hasIdle := false
+		for _, f := range sc.Flags {
+			if f.Name == "idle-timeout" {
+				hasIdle = true
+				break
+			}
+		}
+		if !hasIdle {
+			t.Error("knownSubcommands `serve` should declare --idle-timeout for nested completion")
+		}
+		return
+	}
+	t.Error("knownSubcommands should offer `serve` as a position-1 subcommand")
+}
+
+// --- parseServeIdleTimeout grammar tests ---
+//
+// AC #84:
+//   - `serve --idle-timeout 5m` honored.
+//   - `serve --idle-timeout 5` accepts the bare-number-is-minutes shape.
+//
+// The bare-number grammar is the load-bearing divergence from the pre-#84
+// root-flag parser (PR #76 rejected bare numbers under --idle-timeout). The
+// table covers the AC plus the boundary cases — empty, zero, negative, and
+// junk — so the runner's behaviour is pinned in both directions.
+
+func TestParseServeIdleTimeout_Default(t *testing.T) {
+	got, err := parseServeIdleTimeout("", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != defaultServeIdleTimeout {
+		t.Errorf("default: got %v, want %v", got, defaultServeIdleTimeout)
+	}
+}
+
+func TestParseServeIdleTimeout_PresentEmpty(t *testing.T) {
+	// `serve --idle-timeout` (last token, no value) leaves r.Strings[""]
+	// per cmd.Parse — match the historical tolerance: fall back to default.
+	got, err := parseServeIdleTimeout("", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != defaultServeIdleTimeout {
+		t.Errorf("present-empty: got %v, want %v", got, defaultServeIdleTimeout)
+	}
+}
+
+func TestParseServeIdleTimeout_BareNumberIsMinutes(t *testing.T) {
+	// AC #84: `serve --idle-timeout 5` ≡ `serve --idle-timeout 5m`.
+	cases := []struct {
+		raw  string
+		want time.Duration
+	}{
+		{"5", 5 * time.Minute},
+		{"30", 30 * time.Minute},
+		{"1", 1 * time.Minute},
+		{"0", 0},
+	}
+	for _, c := range cases {
+		t.Run(c.raw, func(t *testing.T) {
+			got, err := parseServeIdleTimeout(c.raw, true)
+			if err != nil {
+				t.Fatalf("--idle-timeout=%s unexpected error: %v", c.raw, err)
+			}
+			if got != c.want {
+				t.Errorf("--idle-timeout=%s: got %v, want %v", c.raw, got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseServeIdleTimeout_DurationStrings(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want time.Duration
+	}{
+		{"30s", 30 * time.Second},
+		{"5m", 5 * time.Minute},
+		{"1h", 1 * time.Hour},
+		{"90m", 90 * time.Minute},
+	}
+	for _, c := range cases {
+		t.Run(c.raw, func(t *testing.T) {
+			got, err := parseServeIdleTimeout(c.raw, true)
+			if err != nil {
+				t.Fatalf("--idle-timeout=%s unexpected error: %v", c.raw, err)
+			}
+			if got != c.want {
+				t.Errorf("--idle-timeout=%s: got %v, want %v", c.raw, got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseServeIdleTimeout_ZeroDisables(t *testing.T) {
+	// `0` (bare or "0s") must produce a zero duration so the
+	// lifecycle wrapper interprets it as "idle timeout disabled."
+	for _, raw := range []string{"0", "0s", "0m"} {
+		got, err := parseServeIdleTimeout(raw, true)
+		if err != nil {
+			t.Fatalf("--idle-timeout=%s unexpected error: %v", raw, err)
+		}
+		if got != 0 {
+			t.Errorf("--idle-timeout=%s: got %v, want 0 (disabled)", raw, got)
+		}
+	}
+}
+
+func TestParseServeIdleTimeout_NegativeRejected(t *testing.T) {
+	for _, raw := range []string{"-5", "-1h"} {
+		_, err := parseServeIdleTimeout(raw, true)
+		if err == nil {
+			t.Errorf("--idle-timeout=%s should error (negative)", raw)
+		}
+	}
+}
+
+func TestParseServeIdleTimeout_JunkRejected(t *testing.T) {
+	cases := []string{"5min", "abc", "5x"}
+	for _, raw := range cases {
+		t.Run(raw, func(t *testing.T) {
+			_, err := parseServeIdleTimeout(raw, true)
+			if err == nil {
+				t.Errorf("--idle-timeout=%s should error (not a duration)", raw)
+			}
+		})
+	}
+}
+
+// TestServeCommandParse_SyntheticArgs exercises serveCommand.Parse end-to-end
+// with a representative arg list to confirm the tree-driven parser
+// recognises every flag the dispatcher reads. If a flag is missed, it falls
+// into Positional (which runServeCommand explicitly rejects), so this test
+// guards the dispatch path against silent flag-passthrough regressions.
+func TestServeCommandParse_SyntheticArgs(t *testing.T) {
+	args := []string{
+		"--profile", "aidev",
+		"--port", "8080",
+		"--upstream", "https://gw.example.com",
+		"--model", "custom-model",
+		"--proxy-api-key", "secret-key",
+		"--tls-cert", "/tmp/cert.pem",
+		"--tls-key", "/tmp/key.pem",
+		"--log-file", "/tmp/log.txt",
+		"--verbose",
+		"--no-update-check",
+		"--idle-timeout", "5",
+	}
+	r, err := serveCommand.Parse(args)
+	if err != nil {
+		t.Fatalf("serveCommand.Parse unexpected error: %v", err)
+	}
+	if len(r.Positional) != 0 {
+		t.Errorf("serveCommand.Parse should consume all flags; leftover Positional=%v", r.Positional)
+	}
+	want := map[string]string{
+		"profile":       "aidev",
+		"port":          "8080",
+		"upstream":      "https://gw.example.com",
+		"model":         "custom-model",
+		"proxy-api-key": "secret-key",
+		"tls-cert":      "/tmp/cert.pem",
+		"tls-key":       "/tmp/key.pem",
+		"log-file":      "/tmp/log.txt",
+		"idle-timeout":  "5",
+	}
+	for k, v := range want {
+		if r.Strings[k] != v {
+			t.Errorf("Strings[%q] = %q, want %q", k, r.Strings[k], v)
+		}
+	}
+	if !r.Bools["verbose"] {
+		t.Error("Bools[verbose] should be true")
+	}
+	if !r.Bools["no-update-check"] {
+		t.Error("Bools[no-update-check] should be true")
+	}
+}


### PR DESCRIPTION
Tracker PR for the CLI command-tree restructure milestone (umbrella #81). **Do not merge** until all sub-issues land.

## Sub-issues (dependency-ordered)

- [ ] #82 — Command-tree registry; migrate root + `config show` (`feat!:` — `--print-env` removed)
- [ ] #83 — `hooks` subcommand (`feat!:`)
- [ ] #84 — `serve` subcommand: absorb `--headless` / `--idle-timeout` (`feat!:`)

Ordering: #82 → #83 → #84 (linear — hooks/serve share the `headlessEnsure` plumbing that `serve` will absorb).

OpenCode has no client-side telemetry surface, so there is no `config otel` parallel to databricks-claude #172 / databricks-codex #87. `config show` rides along with the foundation sub-issue.

## Workflow

- Sub-PRs target this branch (`feat/cli-command-tree`), **not master**.
- Sub-branches: `issue/<N>-<slug>` cut off this integration branch.
- CI runs on this integration branch after each sub-PR merge — `.github/workflows/*.yml` `push:` and `pull_request:` triggers must glob `[master, 'feat/**']` (landed by #82).
- Whole integration branch merges to `master` once all sub-issues are done.

## Architecture invariants (full detail in #81)

- Transparent-proxy default path stays flag-driven and bare.
- Hooks deployment mode stays a first-class option — opencode plugin manifest is the deployment artifact; only the invoking command renames.
- Source of truth becomes a command tree, declared once, that generates parsing + help + completion.

Mirrors databricks-claude integration branch (#170 → #171 → #172/#173 → #174) and databricks-codex tracker.
