### PR TITLE
feat!: hooks subcommand (install/uninstall/session-start) (#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ make build
 | `--tls-key` | Path to TLS private key file (requires --tls-cert) |
 | `--headless` | Start proxy without launching opencode (for IDE extensions or hooks) |
 | `--idle-timeout` | Idle timeout for headless mode (default 30m; `0` disables; bare number = minutes) |
-| `--install-hooks` | Install opencode plugin for automatic proxy lifecycle |
-| `--uninstall-hooks` | Remove databricks-opencode plugin from opencode |
 | `--version` | Print version and exit |
 | `--help`, `-h` | Show help message |
+
+> **Breaking change (v0.8.0):** `--install-hooks`, `--uninstall-hooks`, and `--headless-ensure` have been removed in favour of the [`hooks` subcommand](#hooks-subcommand) below.
 
 ## `config` Subcommand
 
@@ -108,19 +108,25 @@ databricks-opencode config show --profile my-workspace
 
 No shell alias needed — `databricks-opencode` is a standalone binary.
 
-## Session Hooks (automatic proxy lifecycle)
+## `hooks` Subcommand
 
-Install hooks so every OpenCode session auto-starts the proxy on startup — no manual `--headless` needed.
+Install hooks so every OpenCode session auto-starts the proxy on startup — no manual `--headless` needed. The `hooks` subcommand consolidates the lifecycle commands that previously lived behind root flags.
+
+| Subcommand | Description |
+|------------|-------------|
+| `hooks install` | Write the opencode plugin and register it in `opencode.json`. Idempotent. |
+| `hooks uninstall` | Remove the databricks-opencode plugin. Tolerates "not installed". |
+| `hooks session-start` | Plugin-invoked internal — start the proxy if not running (replaces the removed `--headless-ensure` root flag). |
 
 > **First-time setup:** Run `databricks-opencode` at least once before installing hooks. This writes `~/.config/opencode/opencode.json` so the proxy is used for all OpenCode sessions.
 
 ### Install
 
 ```bash
-databricks-opencode --install-hooks
+databricks-opencode hooks install
 ```
 
-This writes an OpenCode plugin to `~/.config/opencode/plugins/databricks-proxy/index.js` that runs `databricks-opencode --headless-ensure` at session startup.
+This writes an OpenCode plugin to `~/.config/opencode/plugins/databricks-proxy/index.js` that runs `databricks-opencode hooks session-start` at session startup.
 
 ### Shutdown
 
@@ -129,15 +135,17 @@ Unlike Claude Code, OpenCode does not have a session-end hook event. The proxy s
 ### Uninstall
 
 ```bash
-databricks-opencode --uninstall-hooks
+databricks-opencode hooks uninstall
 ```
 
 Removes only the databricks-opencode plugin file. Other plugins in your opencode plugins directory are untouched.
 
 ### Notes
 
-- Safe to rerun `--install-hooks` after upgrades — the plugin file is overwritten, not duplicated.
+- Safe to rerun `hooks install` after upgrades — the plugin file is overwritten, not duplicated.
 - Custom port settings persist automatically via the state file (`~/.config/opencode/.databricks-opencode.json`).
+
+> **Migration (v0.8.0):** The legacy root flags `--install-hooks`, `--uninstall-hooks`, and `--headless-ensure` have been removed. **If you have a stale plugin from before v0.8.0**, its session-start invocation still references `--headless-ensure` and will fail at session start. Re-run `databricks-opencode hooks install` once after upgrading to refresh the plugin file. There is no automatic detection — the wrapper does not rewrite plugin files behind your back.
 
 ## Shell Tab Completions
 

--- a/commands.go
+++ b/commands.go
@@ -74,9 +74,6 @@ var rootCommand = cmd.Command{
 		{Name: "tls-key", Description: "TLS private key file for the local proxy (requires --tls-cert)", TakesArg: true, Completer: "__files"},
 		{Name: "headless", Description: "Start proxy without launching opencode (for IDE extensions or hooks)"},
 		{Name: "idle-timeout", Description: "Idle timeout for headless mode (default 30m; 0 disables; bare number = minutes)", TakesArg: true},
-		{Name: "install-hooks", Description: "Install opencode plugin for automatic proxy lifecycle"},
-		{Name: "uninstall-hooks", Description: "Remove databricks-opencode plugin from opencode"},
-		{Name: "headless-ensure", Description: "Ensure headless proxy is running (called by opencode plugin)"},
 		{Name: "no-update-check", Description: "Skip the automatic update check on startup", EnvVar: "DATABRICKS_NO_UPDATE_CHECK"},
 	},
 
@@ -89,6 +86,7 @@ var rootCommand = cmd.Command{
 		{Name: "completion", Short: "Generate shell completion scripts (bash, zsh, fish)"},
 		{Name: "update", Short: "Check for a newer release and print upgrade instructions"},
 		configCommand,
+		hooksCommand,
 	},
 }
 
@@ -150,9 +148,6 @@ Databricks-OpenCode Flags:
   --port int                Local proxy port (default: 49156, saved for future sessions)
   --headless            Start proxy without launching opencode (for IDE extensions)
   --idle-timeout duration   Idle timeout for headless mode (default 30m, 0 disables; use e.g. 30s, 5m, 1h)
-  --install-hooks       Install opencode plugin hooks for automatic proxy lifecycle
-  --uninstall-hooks     Remove databricks-opencode plugin from opencode config
-  --headless-ensure     Start proxy if not running (called by opencode plugin at init)
   --no-update-check            Skip the automatic update check on startup
   --version             Print version and exit
   --help, -h            Show this help message
@@ -165,6 +160,12 @@ Subcommands:
                                                                  (replaces the removed
                                                                  root diagnostic flag)
                                Run 'databricks-opencode config --help' for details.
+  hooks <subcommand>           OpenCode plugin lifecycle.
+                                 hooks install                   Install opencode plugin
+                                 hooks uninstall                 Remove opencode plugin
+                                 hooks session-start             Plugin-invoked internal
+                                                                 (replaces removed root flag)
+                               Run 'databricks-opencode hooks --help' for details.
 
 ────────────────────────────────────────────────────────────────────────────────
 OpenCode CLI Options:
@@ -218,4 +219,150 @@ Example output:
     ANTHROPIC_BASE_URL: https://adb-.../ai-gateway/anthropic
     Auth Token:         **** (redacted)
     OpenCode binary:    /usr/local/bin/opencode
+`
+
+// hooksCommand declares the `hooks` subcommand tree introduced in #83.
+// Consolidates the 3 hooks-lifecycle root flags (--install-hooks,
+// --uninstall-hooks, --headless-ensure) under a discoverable subcommand.
+// install/uninstall manage the opencode plugin file at
+// <opencode-config-dir>/plugins/databricks-proxy/index.js;
+// session-start is the plugin-invoked refcount-free proxy lifecycle internal
+// (formerly --headless-ensure).
+//
+// Tree shape:
+//
+//	hooks
+//	├── install        [--profile P] [--port N]
+//	├── uninstall
+//	└── session-start  [--port N]   (plugin-invoked internal)
+//
+// Unlike databricks-claude, OpenCode has no SessionEnd hook event — the
+// proxy shuts itself down on its idle timeout. So there is no
+// `hooks session-end` counterpart.
+//
+// The hook-install logic in hooks.go (installHooks/uninstallHooks/
+// headlessEnsure) is unchanged; this dispatcher is purely a surface reshape
+// so the lifecycle is discoverable and the internal entrypoint stops
+// polluting the user-facing root flag namespace. The plugin JS file emitted
+// by installHooks is updated to invoke `hooks session-start` instead of
+// `--headless-ensure` — users with stale plugins from before #83 must
+// re-run `hooks install` to refresh the file.
+var hooksCommand = cmd.Command{
+	Name:  "hooks",
+	Short: "OpenCode plugin lifecycle: install/uninstall + session-start internal",
+	Long:  hooksHelpTemplate,
+	Subcommands: []cmd.Command{
+		{
+			Name:  "install",
+			Short: "Install the opencode plugin for automatic proxy lifecycle",
+			Long:  hooksInstallHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "profile", Description: "Databricks CLI profile to persist (default: DEFAULT)", TakesArg: true, Completer: "__databricks_profiles", StateKey: "profile", MDMKey: "databricksProfile", Default: "DEFAULT"},
+				{Name: "port", Description: "Proxy listen port to persist (default: 49156)", TakesArg: true, StateKey: "port", Default: "49156"},
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+		{
+			Name:  "uninstall",
+			Short: "Remove the databricks-opencode plugin from opencode",
+			Long:  hooksUninstallHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+		{
+			Name:  "session-start",
+			Short: "Start proxy if not running (invoked by the opencode plugin — internal)",
+			Long:  hooksSessionStartHelpTemplate,
+			Flags: []cmd.FlagDef{
+				{Name: "port", Description: "Proxy listen port (default: saved state > 49156)", TakesArg: true, StateKey: "port", Default: "49156"},
+				{Name: "help", Short: "h", Description: "Show help message"},
+			},
+		},
+	},
+}
+
+const hooksHelpTemplate = `Usage: databricks-opencode hooks <subcommand> [flags]
+
+OpenCode plugin lifecycle. Installs an opencode plugin at
+<opencode-config-dir>/plugins/databricks-proxy/index.js that spins the
+local proxy up on session start — making 'databricks-opencode' auto-launch
+with every opencode session without a long-lived daemon.
+
+Subcommands:
+  install        Write the opencode plugin and register it in
+                 opencode.json. Idempotent — safe to re-run after
+                 upgrades.
+  uninstall      Remove the databricks-opencode plugin file and config
+                 entry. Tolerates "not installed".
+  session-start  Plugin-invoked internal: start the proxy if it isn't
+                 already running. Called by the opencode plugin written
+                 by 'hooks install'. Not intended to be invoked directly.
+
+Run 'databricks-opencode hooks <subcommand> --help' for per-subcommand flags.
+
+Examples:
+  # First-time install on a developer machine:
+  databricks-opencode hooks install
+
+  # Remove plugin (e.g. when switching to a different proxy management mode):
+  databricks-opencode hooks uninstall
+
+Migration note (v0.8.0): the legacy root flags --install-hooks,
+--uninstall-hooks, and --headless-ensure have been removed in favour of
+this subcommand. Users with stale plugins from before v0.8.0 must re-run
+'hooks install' so the plugin invokes 'hooks session-start' rather than
+the removed '--headless-ensure' flag.
+
+Exit codes:
+  0   success
+  1   write/discovery failure
+  2   missing or unknown subcommand
+`
+
+const hooksInstallHelpTemplate = `Usage: databricks-opencode hooks install [flags]
+
+Install the opencode plugin so every OpenCode session auto-starts the
+local proxy on session init. Writes the plugin to:
+  <opencode-config-dir>/plugins/databricks-proxy/index.js
+and registers it in opencode.json. Idempotent — safe to re-run after
+upgrades or after switching install methods (Homebrew ↔ go install).
+
+Generated plugin invocation:
+  $` + "`" + `<wrapper> hooks session-start` + "`" + `
+
+Flags:
+  --profile string   Databricks CLI profile to persist (default: DEFAULT)
+  --port int         Proxy listen port to persist (default: 49156)
+  --help, -h         Show this help message
+
+Examples:
+  # First-time install on a developer machine:
+  databricks-opencode hooks install
+
+  # Re-install after upgrade (idempotent):
+  databricks-opencode hooks install
+`
+
+const hooksUninstallHelpTemplate = `Usage: databricks-opencode hooks uninstall
+
+Remove the databricks-opencode plugin file and its entry from
+opencode.json. Tolerates "not installed" — safe to run when no plugin is
+present. Other plugins in your opencode plugins directory are untouched.
+
+Flags:
+  --help, -h   Show this help message
+`
+
+const hooksSessionStartHelpTemplate = `Usage: databricks-opencode hooks session-start [flags]
+
+Plugin-invoked internal: start the local proxy if not already running.
+Called by the opencode plugin file written by 'hooks install'. Not
+intended to be invoked directly by end users.
+
+Replaces the legacy --headless-ensure root flag.
+
+Flags:
+  --port int   Proxy listen port (default: saved state > 49156)
+  --help, -h   Show this help message
 `

--- a/completion_flags.go
+++ b/completion_flags.go
@@ -19,3 +19,13 @@ var flagDefs = func() []completion.FlagDef {
 // Derived from rootCommand so it can never drift from the tree or the
 // completion script.
 var knownFlags = rootCommand.KnownFlags()
+
+// knownSubcommands is the set of top-level subcommands surfaced as
+// position-1 completions when the user types `databricks-opencode <TAB>`.
+// Derived recursively from the root command-tree so nested subcommands
+// (e.g. `hooks install`, `config show`) get nested completion automatically.
+// #83 wires this in so the new `hooks` subcommand and its install /
+// uninstall / session-start children complete out of the box; the same
+// derivation also surfaces `config show` from #82 which had been silently
+// invisible to the completion script.
+var knownSubcommands = rootCommand.CompletionSubcommands()

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/IceRhymers/databricks-opencode
 go 1.22
 
 require (
-	github.com/IceRhymers/databricks-claude v0.17.0
+	github.com/IceRhymers/databricks-claude v1.0.2
 	github.com/tidwall/jsonc v0.3.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/IceRhymers/databricks-claude v0.17.0 h1:YPJgXMLBMmmr3uhgZWLTPbsikTnYOOpRdiDTWakzoQo=
 github.com/IceRhymers/databricks-claude v0.17.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
+github.com/IceRhymers/databricks-claude v1.0.2 h1:kfmmOCDPGCbk8t5mDkLXqIQeLdyDEmW1NGKKW4Kw1cQ=
+github.com/IceRhymers/databricks-claude v1.0.2/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
 github.com/tidwall/jsonc v0.3.2 h1:ZTKrmejRlAJYdn0kcaFqRAKlxxFIC21pYq8vLa4p2Wc=
 github.com/tidwall/jsonc v0.3.2/go.mod h1:dw+3CIxqHi+t8eFSpzzMlcVYxKp08UP5CD8/uSFCyJE=

--- a/hooks.go
+++ b/hooks.go
@@ -12,7 +12,7 @@ import (
 
 // headlessEnsure checks whether the proxy is healthy on the given port.
 // If not, it starts a detached headless proxy and polls until ready (max 10s).
-// Called by the opencode plugin at init via: databricks-opencode --headless-ensure
+// Called by the opencode plugin at init via: databricks-opencode hooks session-start
 //
 // No refcount is acquired here — OpenCode has no exit hook to release it,
 // so the proxy relies on its idle timeout for shutdown instead.
@@ -42,15 +42,21 @@ func refcountPathForPort(port int) string {
 // Shutdown is handled by the proxy's idle timeout — OpenCode has no exit hook.
 // %s is replaced with the absolute path to the binary at install time so the
 // plugin works regardless of Bun's PATH (which may not include ~/go/bin or /opt/homebrew/bin).
+//
+// The wrapper is invoked via the `hooks session-start` subcommand (introduced
+// in #83). Users on a stale plugin from before #83 will see the old
+// `--headless-ensure` invocation fail at session start — they must re-run
+// `databricks-opencode hooks install` to refresh the plugin file.
 const pluginJSTemplate = `export const DatabricksProxy = async ({ $ }) => {
-  await $` + "`" + `%s --headless-ensure` + "`" + `;
+  await $` + "`" + `%s hooks session-start` + "`" + `;
   return {};
 };
 `
 
 // installHooks writes the JS plugin and registers it in opencode.json.
-// The absolute path to the binary is baked in at install time; rerun --install-hooks after
-// reinstalling via a different method (e.g. switching from go install to Homebrew).
+// The absolute path to the binary is baked in at install time; rerun
+// `hooks install` after reinstalling via a different method (e.g. switching
+// from go install to Homebrew).
 func installHooks() error {
 	self, err := os.Executable()
 	if err != nil {

--- a/hooks_cmd.go
+++ b/hooks_cmd.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/IceRhymers/databricks-opencode/internal/cmd"
+)
+
+// runHooksCommand implements `databricks-opencode hooks ...`. args is
+// everything after the literal "hooks" token. Dispatches install / uninstall
+// / session-start. Bare `hooks` (no args) prints help and exits 2 — same
+// convention as `config` with no action.
+//
+// Introduced in #83 to consolidate the 3 hooks-lifecycle root flags
+// (--install-hooks, --uninstall-hooks, --headless-ensure) off the root
+// command. The hook-install logic and refcount-free proxy lifecycle in
+// hooks.go are unchanged behaviorally; this dispatcher is purely a surface
+// reshape so the lifecycle is discoverable and the internal entrypoint stops
+// polluting the user-facing root flag namespace.
+func runHooksCommand(args []string) {
+	if len(args) == 0 {
+		_ = cmd.Render(os.Stderr, hooksCommand, nil)
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "install":
+		runHooksInstall(args[1:])
+	case "uninstall":
+		runHooksUninstall(args[1:])
+	case "session-start":
+		runHooksSessionStart(args[1:])
+	case "--help", "-h", "help":
+		_ = cmd.Render(os.Stdout, hooksCommand, nil)
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "databricks-opencode: unknown hooks subcommand %q\n\n", args[0])
+		_ = cmd.Render(os.Stderr, hooksCommand, nil)
+		os.Exit(1)
+	}
+}
+
+// runHooksInstall implements `databricks-opencode hooks install`. Lifts the
+// pre-#83 --install-hooks block from main.go. Persists profile/port to
+// state when explicitly provided and writes the JS plugin into the opencode
+// plugins directory. Idempotent — re-running overwrites the plugin file
+// rather than duplicating it.
+func runHooksInstall(args []string) {
+	node := hooksCommand.Subcommand("install")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	// Persist explicit profile/port overrides so the plugin's session-start
+	// invocation picks them up via the saved state file. Mirrors the
+	// implicit persistence that the legacy --install-hooks path got via
+	// running through main()'s top-level resolution chain.
+	if profile := r.Strings["profile"]; profile != "" {
+		s := loadState()
+		if s.Profile != profile {
+			s.Profile = profile
+			if err := saveState(s); err != nil {
+				log.Printf("databricks-opencode: failed to save profile: %v", err)
+			}
+		}
+	}
+	if portStr := r.Strings["port"]; portStr != "" {
+		if port := atoiOrZero(portStr); port > 0 {
+			s := loadState()
+			if s.Port != port {
+				s.Port = port
+				if err := saveState(s); err != nil {
+					log.Printf("databricks-opencode: failed to save port: %v", err)
+				}
+			}
+		}
+	}
+
+	if err := installHooks(); err != nil {
+		log.Fatalf("databricks-opencode: hooks install: %v", err)
+	}
+	hookDir, _ := opencodeConfigDir()
+	fmt.Fprintf(os.Stderr, "databricks-opencode: hooks installed — opencode plugin written to %s\n", filepath.Join(hookDir, "plugins", "databricks-proxy", "index.js"))
+}
+
+// runHooksUninstall implements `databricks-opencode hooks uninstall`. Lifts
+// the pre-#83 --uninstall-hooks block from main.go. Tolerates "not
+// installed" — uninstallHooks leaves opencode.json alone when the plugin
+// entry is absent and no-ops on the missing plugin file.
+func runHooksUninstall(args []string) {
+	node := hooksCommand.Subcommand("uninstall")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	if err := uninstallHooks(); err != nil {
+		log.Fatalf("databricks-opencode: hooks uninstall: %v", err)
+	}
+	fmt.Fprintln(os.Stderr, "databricks-opencode: hooks removed from opencode config")
+}
+
+// runHooksSessionStart implements `databricks-opencode hooks session-start`.
+// Plugin-invoked internal — replaces the legacy --headless-ensure flag.
+// Spawns a detached headless proxy if not already healthy on the resolved
+// port. No refcount: OpenCode has no SessionEnd hook to release one, so the
+// proxy relies on its idle timeout for shutdown.
+func runHooksSessionStart(args []string) {
+	node := hooksCommand.Subcommand("session-start")
+	r, _ := node.Parse(args)
+	if r.Bools["help"] {
+		_ = cmd.Render(os.Stdout, *node, nil)
+		os.Exit(0)
+	}
+
+	state := loadState()
+	port := resolvePort(atoiOrZero(r.Strings["port"]), state)
+	if err := headlessEnsure(port); err != nil {
+		log.Fatalf("databricks-opencode: headless ensure failed: %v", err)
+	}
+}

--- a/hooks_cmd_test.go
+++ b/hooks_cmd_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- #83 hooks tree parity tests ---
+//
+// The command-tree registry in commands.go is the single source of truth for
+// the hooks subcommand surface. These tests pin the tree shape: the children
+// the dispatcher (runHooksCommand) cares about are present, each carries the
+// flags the runner reads from r.Strings/r.Bools, and the top-level node is a
+// pure dispatcher with no flags of its own.
+//
+// Bidirectional verification was performed during #83: temporarily removing
+// `hooksCommand` from rootCommand.Subcommands causes
+// TestHooksCommandTreeParity to fail loudly (rootCommand.Subcommand("hooks")
+// returns nil), confirming the test catches drift in either direction.
+
+// TestHooksCommandTreeParity walks the hooks subcommand tree and asserts the
+// children the dispatcher routes to (install / uninstall / session-start)
+// are declared with the expected flag set. If a runner is added without a
+// tree node — or a flag is plumbed through a runner without being declared
+// on the tree — this test fails loudly so completion + help stay aligned.
+func TestHooksCommandTreeParity(t *testing.T) {
+	root := rootCommand.Subcommand("hooks")
+	if root == nil {
+		t.Fatal("rootCommand should have a `hooks` subcommand declared")
+	}
+	if len(root.AllFlags()) != 0 {
+		t.Errorf("hooks (top-level dispatcher) should declare no flags of its own; got %d", len(root.AllFlags()))
+	}
+
+	cases := []struct {
+		name      string
+		wantFlags []string
+	}{
+		{name: "install", wantFlags: []string{"--profile", "--port", "--help"}},
+		{name: "uninstall", wantFlags: []string{"--help"}},
+		{name: "session-start", wantFlags: []string{"--port", "--help"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			node := hooksCommand.Subcommand(c.name)
+			if node == nil {
+				t.Fatalf("hooksCommand should have a %q child", c.name)
+			}
+			known := node.KnownFlags()
+			for _, want := range c.wantFlags {
+				if !known[want] {
+					t.Errorf("hooks %s missing %q in its known-flag set", c.name, want)
+				}
+			}
+			// Catch the reverse: any flag declared on the tree must be
+			// expected by this assertion. Surfacing a stray flag here means
+			// either the tree gained a flag the runner doesn't read OR this
+			// test went stale; either is a drift signal.
+			for k := range known {
+				found := false
+				for _, want := range c.wantFlags {
+					if k == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("hooks %s has unexpected flag %q (update test or remove flag)", c.name, k)
+				}
+			}
+		})
+	}
+}
+
+// TestHooksCommandHasNestedSubcommands asserts the install/uninstall/
+// session-start children are declared so completion can offer them nested
+// (`databricks-opencode hooks <TAB>` → install/uninstall/session-start).
+// Drives the AC: "Shell completion completes `hooks <TAB>`".
+func TestHooksCommandHasNestedSubcommands(t *testing.T) {
+	want := []string{"install", "uninstall", "session-start"}
+	got := make(map[string]bool, len(hooksCommand.Subcommands))
+	for _, s := range hooksCommand.Subcommands {
+		got[s.Name] = true
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("hooksCommand should have nested `%s` subcommand for nested completion", w)
+		}
+	}
+}
+
+// TestRootCompletionOffersHooksSubcommand asserts `hooks` is surfaced in the
+// root command-tree's CompletionSubcommands output, with all three children
+// reachable through the recursive walk. Without this, `databricks-opencode
+// <TAB>` would not offer `hooks`, and `hooks <TAB>` would not offer the
+// leaves.
+func TestRootCompletionOffersHooksSubcommand(t *testing.T) {
+	for _, sc := range knownSubcommands {
+		if sc.Name == "hooks" {
+			gotChildren := make(map[string]bool, len(sc.Subcommands))
+			for _, child := range sc.Subcommands {
+				gotChildren[child.Name] = true
+			}
+			for _, want := range []string{"install", "uninstall", "session-start"} {
+				if !gotChildren[want] {
+					t.Errorf("knownSubcommands `hooks` is missing nested child %q (recursive completion broken)", want)
+				}
+			}
+			return
+		}
+	}
+	t.Error("knownSubcommands should offer `hooks` as a position-1 subcommand")
+}
+
+// TestPluginJSTemplate_InvokesNewSubcommand is the load-bearing JS-content
+// check: the plugin file must invoke `<wrapper> hooks session-start` (the
+// new subcommand introduced in #83), not the legacy `--headless-ensure` root
+// flag (which #83 removed). Drives the migration callout — users with stale
+// plugins from before #83 see the legacy invocation fail at session start
+// because the flag no longer exists.
+func TestPluginJSTemplate_InvokesNewSubcommand(t *testing.T) {
+	if !strings.Contains(pluginJSTemplate, "hooks session-start") {
+		t.Errorf("pluginJSTemplate should invoke `<wrapper> hooks session-start`, got:\n%s", pluginJSTemplate)
+	}
+	if strings.Contains(pluginJSTemplate, "--headless-ensure") {
+		t.Errorf("pluginJSTemplate must not invoke the removed --headless-ensure flag, got:\n%s", pluginJSTemplate)
+	}
+}
+
+// TestInstallHooksIdempotency walks the full install → install → uninstall →
+// uninstall cycle in an isolated $XDG_CONFIG_HOME and asserts:
+//
+//  1. Re-running install overwrites the plugin file rather than duplicating
+//     it (file content is byte-identical between runs).
+//  2. Re-running uninstall when nothing is installed is a no-op (no error,
+//     no leftover plugin file).
+//
+// Uses t.Setenv("XDG_CONFIG_HOME", …) so opencodeConfigDir resolves to a
+// per-test temp directory without leaking into the user's real config —
+// the critical pitfall called out in the #83 plan.
+func TestInstallHooksIdempotency(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	pluginPath := filepath.Join(dir, "opencode", "plugins", "databricks-proxy", "index.js")
+
+	// --- 1. First install ---
+	if err := installHooks(); err != nil {
+		t.Fatalf("first installHooks: %v", err)
+	}
+	first, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("plugin file missing after first install: %v", err)
+	}
+	if !strings.Contains(string(first), "hooks session-start") {
+		t.Errorf("plugin file should invoke `hooks session-start` after install, got:\n%s", string(first))
+	}
+
+	// --- 2. Second install: byte-identical content (idempotent) ---
+	if err := installHooks(); err != nil {
+		t.Fatalf("second installHooks: %v", err)
+	}
+	second, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("plugin file missing after second install: %v", err)
+	}
+	if string(first) != string(second) {
+		t.Errorf("plugin file content should be byte-identical between idempotent installs\nfirst:\n%s\nsecond:\n%s", string(first), string(second))
+	}
+
+	// --- 3. First uninstall: removes plugin file ---
+	if err := uninstallHooks(); err != nil {
+		t.Fatalf("first uninstallHooks: %v", err)
+	}
+	if _, err := os.Stat(pluginPath); !os.IsNotExist(err) {
+		t.Errorf("plugin file should not exist after uninstall; got err=%v", err)
+	}
+
+	// --- 4. Second uninstall: no-op (no error) ---
+	if err := uninstallHooks(); err != nil {
+		t.Errorf("second uninstallHooks should be a no-op when plugin is already absent, got: %v", err)
+	}
+}

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -158,6 +158,25 @@ func (c Command) CompletionFlags() []completion.FlagDef {
 	return out
 }
 
+// CompletionSubcommands returns the immediate children as
+// pkg/completion.SubcommandDef. The conversion is RECURSIVE: each child
+// carries its own Flags and Subcommands so the shell-completion generator
+// can offer nested completion (e.g. `hooks <TAB>` → install/uninstall/
+// session-start). Flags include each child's Persistent ++ Flags so
+// inherited flags surface alongside the child's own.
+func (c Command) CompletionSubcommands() []completion.SubcommandDef {
+	out := make([]completion.SubcommandDef, len(c.Subcommands))
+	for i, s := range c.Subcommands {
+		out[i] = completion.SubcommandDef{
+			Name:        s.Name,
+			Description: s.Short,
+			Flags:       s.CompletionFlags(),
+			Subcommands: s.CompletionSubcommands(),
+		}
+	}
+	return out
+}
+
 // KnownFlags returns the set of "--flag" names this command's parser
 // recognises. Includes Persistent ++ Flags. Does NOT walk into
 // Subcommands — each child command is parsed by its own dispatcher and

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 	// completion <shell> — must be the very first check, before any flag parsing,
 	// auth, or state loading. Safe to call in the Homebrew install sandbox.
 	if len(os.Args) >= 2 && os.Args[1] == "completion" {
-		completion.Run(os.Args[2:], flagDefs, "databricks-opencode")
+		completion.Run(os.Args[2:], flagDefs, "databricks-opencode", knownSubcommands...)
 		os.Exit(0)
 	}
 
@@ -45,6 +45,15 @@ func main() {
 	// doesn't have to fight with the transparent-passthrough behaviour.
 	if len(os.Args) >= 2 && os.Args[1] == "config" {
 		runConfigCommand(os.Args[2:])
+		return
+	}
+
+	// `hooks` subcommand — opencode plugin lifecycle. Replaces the removed
+	// --install-hooks / --uninstall-hooks / --headless-ensure root flags.
+	// Routed before parseArgs so positional dispatch doesn't have to fight
+	// with the transparent-passthrough behaviour.
+	if len(os.Args) >= 2 && os.Args[1] == "hooks" {
+		runHooksCommand(os.Args[2:])
 		return
 	}
 
@@ -94,9 +103,6 @@ func main() {
 	portFlag := a.Port
 	headless := a.Headless
 	idleTimeout := a.IdleTimeout
-	installHooksFlag := a.InstallHooksFlag
-	uninstallHooksFlag := a.UninstallHooksFlag
-	headlessEnsureFlag := a.HeadlessEnsureFlag
 	noUpdateCheck := a.NoUpdateCheck
 	opencodeArgs := a.OpencodeArgs
 
@@ -107,33 +113,6 @@ func main() {
 
 	if version {
 		fmt.Printf("databricks-opencode %s\n", Version)
-		os.Exit(0)
-	}
-
-	// --- Hook lifecycle commands (handled before auth/config setup) ---
-	if installHooksFlag || uninstallHooksFlag {
-		if installHooksFlag {
-			if err := installHooks(); err != nil {
-				log.Fatalf("databricks-opencode: --install-hooks: %v", err)
-			}
-			hookDir, _ := opencodeConfigDir()
-			fmt.Fprintf(os.Stderr, "databricks-opencode: hooks installed — opencode plugin written to %s\n", filepath.Join(hookDir, "plugins", "databricks-proxy", "index.js"))
-		} else {
-			if err := uninstallHooks(); err != nil {
-				log.Fatalf("databricks-opencode: --uninstall-hooks: %v", err)
-			}
-			fmt.Fprintln(os.Stderr, "databricks-opencode: hooks removed from opencode config")
-		}
-		os.Exit(0)
-	}
-
-	// --- Headless hook command (called by the opencode plugin, not by end users) ---
-	if headlessEnsureFlag {
-		state := loadState()
-		port := resolvePort(0, state)
-		if err := headlessEnsure(port); err != nil {
-			log.Fatalf("databricks-opencode: headless ensure failed: %v", err)
-		}
 		os.Exit(0)
 	}
 
@@ -413,24 +392,21 @@ func main() {
 
 // Args holds all parsed databricks-opencode flags plus the residual opencode args.
 type Args struct {
-	Verbose            bool
-	Version            bool
-	ShowHelp           bool
-	Model              string
-	Upstream           string
-	LogFile            string
-	Profile            string
-	ProxyAPIKey        string
-	TLSCert            string
-	TLSKey             string
-	Port               int
-	Headless           bool
-	IdleTimeout        time.Duration
-	InstallHooksFlag   bool
-	UninstallHooksFlag bool
-	HeadlessEnsureFlag bool
-	NoUpdateCheck      bool
-	OpencodeArgs       []string
+	Verbose       bool
+	Version       bool
+	ShowHelp      bool
+	Model         string
+	Upstream      string
+	LogFile       string
+	Profile       string
+	ProxyAPIKey   string
+	TLSCert       string
+	TLSKey        string
+	Port          int
+	Headless      bool
+	IdleTimeout   time.Duration
+	NoUpdateCheck bool
+	OpencodeArgs  []string
 }
 
 // parseArgs separates databricks-opencode flags from opencode flags.
@@ -550,12 +526,6 @@ func parseArgs(args []string) (*Args, error) {
 						}
 						a.IdleTimeout = d
 					}
-				case "--install-hooks":
-					a.InstallHooksFlag = true
-				case "--uninstall-hooks":
-					a.UninstallHooksFlag = true
-				case "--headless-ensure":
-					a.HeadlessEnsureFlag = true
 				case "--no-update-check":
 					a.NoUpdateCheck = true
 				default:

--- a/main_test.go
+++ b/main_test.go
@@ -591,11 +591,41 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	out := captureStdout(func() {
 		handleHelp("")
 	})
-	// Note: --print-env removed in #82 (replaced by `config show`); not in this list.
-	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--model", "--version", "--help", "--port", "--headless", "--idle-timeout", "--install-hooks", "--uninstall-hooks", "--headless-ensure", "--no-update-check"}
+	// Note: --print-env removed in #82 (replaced by `config show`); the
+	// hooks lifecycle flags --install-hooks, --uninstall-hooks, and
+	// --headless-ensure removed in #83 (replaced by the `hooks` subcommand
+	// — see TestHandleHelp_HookFlagsRemoved). Neither set is listed here.
+	flags := []string{"--profile", "--upstream", "--verbose", "-v", "--log-file", "--model", "--version", "--help", "--port", "--headless", "--idle-timeout", "--no-update-check"}
 	for _, flag := range flags {
 		if !strings.Contains(out, flag) {
 			t.Errorf("expected help output to contain flag %q, got:\n%s", flag, out)
+		}
+	}
+}
+
+// TestHandleHelp_HookFlagsRemoved verifies that --install-hooks /
+// --uninstall-hooks / --headless-ensure no longer appear in the help body
+// (#83 replaced them with the `hooks` subcommand).
+func TestHandleHelp_HookFlagsRemoved(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp("")
+	})
+	for _, removed := range []string{"--install-hooks", "--uninstall-hooks", "--headless-ensure"} {
+		if strings.Contains(out, removed) {
+			t.Errorf("help output should not mention %q (replaced by `hooks` subcommand), got:\n%s", removed, out)
+		}
+	}
+}
+
+// TestHandleHelp_ContainsHooksSubcommand verifies that the new `hooks`
+// subcommand surfaces in the help body so users can discover it.
+func TestHandleHelp_ContainsHooksSubcommand(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp("")
+	})
+	for _, want := range []string{"hooks install", "hooks uninstall", "hooks session-start"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected help output to mention %q, got:\n%s", want, out)
 		}
 	}
 }


### PR DESCRIPTION
Closes #83. Part of the umbrella restructure in #81.

Consolidates lifecycle root flags under `hooks`:

- `databricks-opencode hooks install` (replaces `--install-hooks`)
- `databricks-opencode hooks uninstall` (replaces `--uninstall-hooks`)
- `databricks-opencode hooks session-start` (replaces internal `--headless-ensure`)

**Breaking change:** the three legacy root flags are removed from `rootCommand`. The opencode plugin's JS template now invokes the wrapper via `<wrapper> hooks session-start` rather than `--headless-ensure`. **Users with stale plugins from prior versions must re-run `hooks install`** to refresh the plugin file — called out in the README.

## Highlights

- `hooks_cmd.go` (NEW, 126 LOC) — dispatcher + three thin handlers wrapping the existing `installHooks` / `uninstallHooks` / `headlessEnsure` functions.
- `hooks_cmd_test.go` (NEW, 185 LOC) — `TestHooksCommandTreeParity` walks `hooksCommand` subcommands and asserts the exact flag set bidirectionally. `TestInstallHooksIdempotency` covers install ×2 → uninstall ×2 → clean state. `TestPluginJSTemplate_InvokesNewSubcommand` pins both presence of the new form and absence of legacy `--headless-ensure`.
- `internal/cmd/cmd.go` — adds `Command.CompletionSubcommands()` (was previously omitted in #82 because `databricks-claude/pkg/completion` v0.17.0 didn't export `SubcommandDef`). Now wired so nested completion (`hooks <TAB>` → install/uninstall/session-start) works at the shell level.
- `go.mod` — bumps `databricks-claude` v0.17.0 → v1.0.2 to gain `pkg/completion.SubcommandDef`.
- `commands.go` — legacy flag declarations removed from `rootCommand.Flags`; `hooksCommand` declared with proper Long body + the three subcommands.
- `main.go` — legacy dispatch branches removed; `hooks` keyword routes to `runHooksCommand` before `parseArgs`.
- README — `## hooks Subcommand` section at top-level heading depth with migration callout.

## Verification

`hooks install` is byte-idempotent (md5 of generated plugin file matches across two installs). `hooks uninstall` after `hooks uninstall` is a clean no-op. Plugin file post-install contains the literal `hooks session-start` invocation and zero references to `--headless-ensure`. Shell completion script contains `local subcmds2="install uninstall session-start"` confirming nested completion is wired.

## Cross-lane review

Reviewed in fresh context (`delegate_task`, Opus) with live smoke tests — verdict: APPROVE. Findings: 1 MINOR (silent `Parse` error swallow, matches house style), 3 NITs (cosmetic). No blockers.

## Pipeline

`autopilot ($7.34, 92 turns, ~12 min) → cross-lane review (APPROVE) → PR`. Mirrors databricks-claude #173 dispatch shape; opencode-specific plugin JS update layered on top.
