### PR TITLE
feat: stop appending opencode --help, document -- passthrough

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -167,8 +167,11 @@ Subcommands:
                                the idle-timeout flag = minutes; 0 disables.
                                Run 'databricks-opencode serve --help' for details.
 
-────────────────────────────────────────────────────────────────────────────────
-OpenCode CLI Options:
+Passthrough to opencode:
+  Anything after a "--" separator is forwarded to the opencode CLI unchanged.
+  Examples:
+    databricks-opencode -- --help              # show opencode's own help
+    databricks-opencode -- --model o3 -p "hi"  # run opencode with extra flags
 `
 
 const configHelpTemplate = `Usage: databricks-opencode config <subcommand> [flags]

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -134,7 +133,7 @@ func runOpencode(a *Args) {
 	opencodeArgs := a.OpencodeArgs
 
 	if showHelp {
-		handleHelp(upstream)
+		handleHelp()
 		os.Exit(0)
 	}
 
@@ -589,30 +588,14 @@ func runHeadless(proxyURL string, ln net.Listener, isOwner bool, doneCh chan str
 	}
 }
 
-// handleHelp prints the databricks-opencode help section, then execs opencode --help.
-// The first half is rendered from the rootCommand registry (commands.go) so
-// the help body, flag set, and completion scripts share one source of truth.
-func handleHelp(upstreamBinary string) {
-	_ = cmd.Render(os.Stdout, rootCommand, map[string]string{"Version": Version})
-
-	opencodeBin := upstreamBinary
-	if opencodeBin == "" {
-		if p, err := exec.LookPath("opencode"); err == nil {
-			opencodeBin = p
-		}
+// handleHelp renders the databricks-opencode help body from the rootCommand
+// registry (commands.go) so the help body, flag set, and completion scripts
+// share one source of truth. The wrapper does not append `opencode --help` —
+// users who want opencode's own help can run `databricks-opencode -- --help`.
+func handleHelp() {
+	if err := cmd.Render(os.Stdout, rootCommand, map[string]string{"Version": Version}); err != nil {
+		fmt.Fprintf(os.Stderr, "databricks-opencode: failed to render help: %v\n", err)
 	}
-
-	if opencodeBin == "" {
-		fmt.Println("(opencode binary not found on PATH — install from https://opencode.ai)")
-		return
-	}
-
-	var buf bytes.Buffer
-	cmd := exec.Command(opencodeBin, "--help")
-	cmd.Stdout = &buf
-	cmd.Stderr = &buf
-	_ = cmd.Run()
-	fmt.Print(buf.String())
 }
 
 // buildUpdaterConfig returns the standard updater.Config for databricks-opencode.

--- a/main_test.go
+++ b/main_test.go
@@ -39,6 +39,20 @@ func TestParseArgs_HelpShort(t *testing.T) {
 	}
 }
 
+// TestParseArgs_SeparatorForwardsHelp verifies that "--" terminates wrapper
+// flag parsing, so "-- --help" must NOT trigger the wrapper's help and must
+// forward "--help" to opencode verbatim. This is the documented passthrough
+// escape hatch users invoke to reach opencode's own help (#90).
+func TestParseArgs_SeparatorForwardsHelp(t *testing.T) {
+	a := mustParse(t, []string{"--", "--help"})
+	if a.ShowHelp {
+		t.Error("expected ShowHelp=false when --help appears after --")
+	}
+	if len(a.OpencodeArgs) != 1 || a.OpencodeArgs[0] != "--help" {
+		t.Errorf("expected OpencodeArgs=[--help], got %v", a.OpencodeArgs)
+	}
+}
+
 // TestParseArgs_PrintEnvRemoved verifies that --print-env is no longer a
 // known flag (replaced by `config show` in #82). Behavior: parseArgs forwards
 // unknown flags to opencode, so --print-env should appear in OpencodeArgs.
@@ -420,7 +434,7 @@ func TestHandlePrintEnv_ContainsModel(t *testing.T) {
 
 func TestHandleHelp_ContainsDatabricksOpencode(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	if !strings.Contains(out, "databricks-opencode") {
 		t.Errorf("expected help output to contain 'databricks-opencode', got:\n%s", out)
@@ -431,7 +445,7 @@ func TestHandleHelp_ContainsDatabricksOpencode(t *testing.T) {
 // appears in the help body (#82 replaced it with `config show`).
 func TestHandleHelp_PrintEnvRemoved(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	if strings.Contains(out, "--print-env") {
 		t.Errorf("help output should not mention --print-env (replaced by 'config show'), got:\n%s", out)
@@ -442,19 +456,40 @@ func TestHandleHelp_PrintEnvRemoved(t *testing.T) {
 // subcommand surfaces in the help body so users can discover `config show`.
 func TestHandleHelp_ContainsConfigSubcommand(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	if !strings.Contains(out, "config show") {
 		t.Errorf("expected help output to mention 'config show', got:\n%s", out)
 	}
 }
 
-func TestHandleHelp_ContainsOpenCodeCLISeparator(t *testing.T) {
+// TestHandleHelp_OmitsAppendedOpencodeHelp verifies that the wrapper no
+// longer execs `opencode --help` and appends its output (#90). The legacy
+// "OpenCode CLI Options:" separator label and the horizontal rule above it
+// must be absent so users see only wrapper help — opencode's own help is
+// reachable via the `--` passthrough escape hatch.
+func TestHandleHelp_OmitsAppendedOpencodeHelp(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
-	if !strings.Contains(out, "OpenCode CLI Options:") {
-		t.Errorf("expected help output to contain 'OpenCode CLI Options:', got:\n%s", out)
+	for _, ghost := range []string{"OpenCode CLI Options:", "────────────────────────"} {
+		if strings.Contains(out, ghost) {
+			t.Errorf("help output should not contain %q (appended opencode help removed in #90), got:\n%s", ghost, out)
+		}
+	}
+}
+
+// TestHandleHelp_DocumentsPassthrough verifies that the help body documents
+// the `--` passthrough escape hatch as the discoverable replacement for the
+// removed appended `opencode --help` block.
+func TestHandleHelp_DocumentsPassthrough(t *testing.T) {
+	out := captureStdout(func() {
+		handleHelp()
+	})
+	for _, want := range []string{"Passthrough to opencode:", "databricks-opencode -- --help"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected help output to contain %q, got:\n%s", want, out)
+		}
 	}
 }
 
@@ -609,7 +644,7 @@ func TestParseArgs_HeadlessDefault(t *testing.T) {
 
 func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	// Note: --print-env removed in #82 (replaced by `config show`); the
 	// hooks lifecycle flags --install-hooks, --uninstall-hooks, and
@@ -634,7 +669,7 @@ func TestHandleHelp_AllFlagsPresent(t *testing.T) {
 // absent — the `serve --idle-timeout` callout in the body is fine.
 func TestHandleHelp_HeadlessFlagsRemoved(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	// "--headless" must not appear at all (the new entrypoint is `serve`).
 	if strings.Contains(out, "--headless") {
@@ -656,7 +691,7 @@ func TestHandleHelp_HeadlessFlagsRemoved(t *testing.T) {
 // replacement for `--headless`.
 func TestHandleHelp_ContainsServeSubcommand(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	if !strings.Contains(out, "serve") {
 		t.Errorf("expected help output to mention `serve` subcommand, got:\n%s", out)
@@ -668,7 +703,7 @@ func TestHandleHelp_ContainsServeSubcommand(t *testing.T) {
 // (#83 replaced them with the `hooks` subcommand).
 func TestHandleHelp_HookFlagsRemoved(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	for _, removed := range []string{"--install-hooks", "--uninstall-hooks", "--headless-ensure"} {
 		if strings.Contains(out, removed) {
@@ -681,7 +716,7 @@ func TestHandleHelp_HookFlagsRemoved(t *testing.T) {
 // subcommand surfaces in the help body so users can discover it.
 func TestHandleHelp_ContainsHooksSubcommand(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	for _, want := range []string{"hooks install", "hooks uninstall", "hooks session-start"} {
 		if !strings.Contains(out, want) {
@@ -692,7 +727,7 @@ func TestHandleHelp_ContainsHooksSubcommand(t *testing.T) {
 
 func TestHandleHelp_ContainsVersion(t *testing.T) {
 	out := captureStdout(func() {
-		handleHelp("")
+		handleHelp()
 	})
 	if !strings.Contains(out, fmt.Sprintf("databricks-opencode v%s", Version)) {
 		t.Errorf("expected help output to contain version string, got:\n%s", out)


### PR DESCRIPTION
## Summary

`databricks-opencode --help` previously printed the wrapper's help (via `cmd.Render`) then shelled out to `opencode --help` and appended its output below a divider. Mixing the two surfaces made it impossible for users to tell which flags the wrapper owns vs which it forwards.

### Changes
- `handleHelp()` now renders only the wrapper help — no upstream binary exec
- `rootHelpTemplate` in `commands.go` documents the existing `--` passthrough escape hatch (`databricks-opencode -- --help`)
- Tests: `TestParseArgs_SeparatorForwardsHelp` + `TestHandleHelp_OmitsAppendedOpencodeHelp` + `TestHandleHelp_DocumentsPassthrough`

Brings parity with databricks-claude's help behavior.

Closes #90
Cross-ref: IceRhymers/databricks-codex#95