### PR TITLE
feat: enable Responses API SSE rewriter via databricks-claude v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/IceRhymers/databricks-opencode
 go 1.22
 
 require (
-	github.com/IceRhymers/databricks-claude v1.1.0
+	github.com/IceRhymers/databricks-claude v1.2.0
 	github.com/tidwall/jsonc v0.3.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/IceRhymers/databricks-claude v1.1.0 h1:0W+t0tyQKL6QsZhaHg6d1d9DvZkP61dLKvq7fWmcOhs=
-github.com/IceRhymers/databricks-claude v1.1.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
+github.com/IceRhymers/databricks-claude v1.2.0 h1:oMbz4b6B7jWmOrW9tJh3qJN0Lr5kCuQCBYIT1/QZqNI=
+github.com/IceRhymers/databricks-claude v1.2.0/go.mod h1:oumYYlTYJnMX94lOok3ammlwLzuPhUhq30DIEFmqwM8=
 github.com/tidwall/jsonc v0.3.2 h1:ZTKrmejRlAJYdn0kcaFqRAKlxxFIC21pYq8vLa4p2Wc=
 github.com/tidwall/jsonc v0.3.2/go.mod h1:dw+3CIxqHi+t8eFSpzzMlcVYxKp08UP5CD8/uSFCyJE=

--- a/main.go
+++ b/main.go
@@ -279,6 +279,12 @@ func runOpencode(a *Args) {
 	geminiGatewayURL := ConstructGeminiGatewayURL(host)
 	log.Printf("databricks-opencode: gemini gateway URL: %s", geminiGatewayURL)
 
+	// OpenAI Responses upstream — always derived from the discovered host
+	// (no --upstream override knob; the /openai/v1 route is path-prefixed off
+	// the same local proxy port so the Responses SSE rewriter still fires).
+	openaiGatewayURL := ConstructOpenAIGatewayURL(host)
+	log.Printf("databricks-opencode: openai gateway URL: %s", openaiGatewayURL)
+
 	// Verify opencode is on PATH before starting proxy (skip in headless mode).
 	if !headless {
 		if _, err := exec.LookPath("opencode"); err != nil {
@@ -296,6 +302,7 @@ func runOpencode(a *Args) {
 	proxyHandler, err := NewProxyServer(&ProxyConfig{
 		InferenceUpstream: gatewayURL,
 		GeminiUpstream:    geminiGatewayURL,
+		OpenAIUpstream:    openaiGatewayURL,
 		TokenProvider:     tp,
 		Verbose:           verbose,
 		APIKey:            proxyAPIKey,

--- a/pkg/jsonconfig/jsonconfig.go
+++ b/pkg/jsonconfig/jsonconfig.go
@@ -3,14 +3,16 @@
 // before parsing, allowing users to write JSONC in their config files.
 //
 // Design: surgical patching only. opencode is a patch-and-leave-it
-// persistent config — we own BOTH the `provider.databricks-proxy` key
-// (Anthropic via @ai-sdk/anthropic on /v1) AND the
-// `provider.databricks-gemini-proxy` key (Gemini Native via
-// @ai-sdk/google on /v1beta) and rewrite them idempotently via Patch on
-// every run that NeedsConfig reports stale. Both providers route through
-// the same local proxy port — Anthropic on the catch-all, Gemini on the
-// /v1beta path-prefix route. No backup, no restore, no crash-recovery
-// sidecar.
+// persistent config — we own three provider keys: `databricks-proxy`
+// (Anthropic via @ai-sdk/anthropic on /v1), `databricks-gemini-proxy`
+// (Gemini Native via @ai-sdk/google on /v1beta), and
+// `databricks-openai-proxy` (OpenAI Responses via @ai-sdk/openai on
+// /openai/v1). All three are rewritten idempotently via Patch on every
+// run that NeedsConfig reports stale. All three route through the same
+// local proxy port — Anthropic on the catch-all, Gemini on the /v1beta
+// path-prefix route, OpenAI on the /openai/v1 path-prefix route (so the
+// proxy's Responses SSE rewriter still fires on /openai/v1/responses).
+// No backup, no restore, no crash-recovery sidecar.
 package jsonconfig
 
 import (
@@ -47,9 +49,10 @@ func (c *Config) Path() string {
 	return c.path
 }
 
-// Patch injects both the databricks-proxy (Anthropic) and
-// databricks-gemini-proxy (Gemini Native) providers and optionally sets
-// the model. If forceModel is true, the model is always written
+// Patch injects all three managed providers — databricks-proxy
+// (Anthropic), databricks-gemini-proxy (Gemini Native), and
+// databricks-openai-proxy (OpenAI Responses) — and optionally sets the
+// active model. If forceModel is true, the model is always written
 // (explicit --model flag). If forceModel is false, the model is only set
 // if absent (preserve-if-present).
 func (c *Config) Patch(proxyURL, modelName, apiKey string, forceModel bool) error {
@@ -114,9 +117,33 @@ func (c *Config) Patch(proxyURL, modelName, apiKey string, forceModel bool) erro
 			"databricks-gemini-2-5-flash":      map[string]interface{}{},
 		},
 	}
+
+	// Inject the databricks-openai-proxy provider (always overwrite — we own
+	// this key too). Uses @ai-sdk/openai; the proxy overwrites auth headers
+	// with the real Databricks token, so the apiKey here is a placeholder.
+	// baseURL points at the local proxy's /openai/v1 path-prefix route so
+	// the Responses SSE rewriter still fires on /openai/v1/responses.
+	providers["databricks-openai-proxy"] = map[string]interface{}{
+		"npm":  "@ai-sdk/openai",
+		"name": "Databricks AI Gateway (OpenAI Responses)",
+		"options": map[string]interface{}{
+			"baseURL": proxyURL + "/openai/v1",
+			"apiKey":  apiKey,
+		},
+		// Register Databricks-hosted OpenAI models so users can switch
+		// between them in OpenCode's model picker without manual config edits.
+		"models": map[string]interface{}{
+			"databricks-gpt-5-5": map[string]interface{}{},
+		},
+	}
 	config["provider"] = providers
 
 	// Set the active model: preserve-if-present unless forced.
+	// TODO(follow-up): hardcoded "databricks-proxy/" prefix breaks --model
+	// selection for non-Anthropic providers (databricks-gemini-proxy,
+	// databricks-openai-proxy). Active-model derivation by model→provider
+	// mapping is tracked as a follow-up issue. Workaround: switch via
+	// OpenCode's in-app model picker.
 	if forceModel {
 		config["model"] = "databricks-proxy/" + modelName
 	} else {
@@ -129,11 +156,12 @@ func (c *Config) Patch(proxyURL, modelName, apiKey string, forceModel bool) erro
 }
 
 // NeedsConfig returns true if config.json needs to be written (or
-// rewritten) because either the databricks-proxy (Anthropic) or
-// databricks-gemini-proxy (Gemini Native) provider is absent or has a
-// stale baseURL / apiKey / npm value. Returns true when the config file
-// is missing, the provider section is absent, or any managed-key drift
-// is detected on either provider.
+// rewritten) because any of the three managed providers — databricks-proxy
+// (Anthropic), databricks-gemini-proxy (Gemini Native), or
+// databricks-openai-proxy (OpenAI Responses) — is absent or has a stale
+// baseURL / apiKey / npm value. Returns true when the config file is
+// missing, the provider section is absent, or any managed-key drift is
+// detected on any provider.
 func (c *Config) NeedsConfig(proxyURL string) bool {
 	config, err := c.readConfig()
 	if err != nil {
@@ -147,6 +175,9 @@ func (c *Config) NeedsConfig(proxyURL string) bool {
 		return true
 	}
 	if needsProviderRefresh(providers, "databricks-gemini-proxy", "@ai-sdk/google", proxyURL+"/v1beta") {
+		return true
+	}
+	if needsProviderRefresh(providers, "databricks-openai-proxy", "@ai-sdk/openai", proxyURL+"/openai/v1") {
 		return true
 	}
 	return false
@@ -176,14 +207,15 @@ func needsProviderRefresh(providers map[string]interface{}, providerKey, wantNPM
 	return npm != wantNPM
 }
 
-// UpdateProxyURL updates the baseURL for both managed providers — the
-// databricks-proxy (Anthropic) at proxyURL+"/v1" and the
-// databricks-gemini-proxy (Gemini Native) at proxyURL+"/v1beta". The
-// argument is the base proxy URL (no API-version suffix); per-provider
-// suffixes are applied internally so callers do not have to know which
-// upstream lives at which path. Returns an error if the
-// databricks-proxy provider is missing — the gemini provider is best-effort
-// (existing pre-upgrade configs without it are not failed by hand-off).
+// UpdateProxyURL updates the baseURL for all three managed providers —
+// databricks-proxy (Anthropic) at proxyURL+"/v1", databricks-gemini-proxy
+// (Gemini Native) at proxyURL+"/v1beta", and databricks-openai-proxy
+// (OpenAI Responses) at proxyURL+"/openai/v1". The argument is the base
+// proxy URL (no API-version suffix); per-provider suffixes are applied
+// internally so callers do not have to know which upstream lives at which
+// path. Returns an error if the databricks-proxy provider is missing —
+// the gemini and openai-proxy providers are best-effort (existing
+// pre-upgrade configs without them are not failed by hand-off).
 func (c *Config) UpdateProxyURL(proxyURL string) error {
 	config, err := c.readConfig()
 	if err != nil {
@@ -216,6 +248,16 @@ func (c *Config) UpdateProxyURL(proxyURL string) error {
 		geminiOpts["baseURL"] = proxyURL + "/v1beta"
 		dbGemini["options"] = geminiOpts
 		providers["databricks-gemini-proxy"] = dbGemini
+	}
+
+	if dbOpenAI, _ := providers["databricks-openai-proxy"].(map[string]interface{}); dbOpenAI != nil {
+		openaiOpts, _ := dbOpenAI["options"].(map[string]interface{})
+		if openaiOpts == nil {
+			openaiOpts = make(map[string]interface{})
+		}
+		openaiOpts["baseURL"] = proxyURL + "/openai/v1"
+		dbOpenAI["options"] = openaiOpts
+		providers["databricks-openai-proxy"] = dbOpenAI
 	}
 
 	config["provider"] = providers

--- a/pkg/jsonconfig/jsonconfig_test.go
+++ b/pkg/jsonconfig/jsonconfig_test.go
@@ -647,3 +647,165 @@ func TestPatch_GeminiModelsRegistered(t *testing.T) {
 		t.Error("models.databricks-gemini-2-5-flash missing")
 	}
 }
+
+// TestPatch_InjectsOpenAIProxyProvider verifies Patch writes the
+// databricks-openai-proxy provider with the correct npm package and the
+// literal /openai/v1 baseURL — asserted as a literal string so a
+// copy-paste typo against gemini's /v1beta would fail this test.
+func TestPatch_InjectsOpenAIProxyProvider(t *testing.T) {
+	c := setupTestConfig(t)
+
+	if err := c.Patch("http://127.0.0.1:49156", "databricks-claude-opus-4-7", "databricks-proxy", false); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	m := readJSON(t, c.Path())
+	providers, _ := m["provider"].(map[string]interface{})
+	if providers == nil {
+		t.Fatal("provider section missing after Patch")
+	}
+
+	openai, _ := providers["databricks-openai-proxy"].(map[string]interface{})
+	if openai == nil {
+		t.Fatal("databricks-openai-proxy provider missing after Patch")
+	}
+	if openai["npm"] != "@ai-sdk/openai" {
+		t.Errorf("databricks-openai-proxy.npm = %v, want %q", openai["npm"], "@ai-sdk/openai")
+	}
+	if openai["name"] != "Databricks AI Gateway (OpenAI Responses)" {
+		t.Errorf("databricks-openai-proxy.name = %v, want %q",
+			openai["name"], "Databricks AI Gateway (OpenAI Responses)")
+	}
+	openaiOpts, _ := openai["options"].(map[string]interface{})
+	if openaiOpts == nil {
+		t.Fatal("databricks-openai-proxy.options missing")
+	}
+	// Literal-string assertion catches copy-paste typos against /v1beta.
+	if openaiOpts["baseURL"] != "http://127.0.0.1:49156/openai/v1" {
+		t.Errorf("databricks-openai-proxy.options.baseURL = %v, want %q",
+			openaiOpts["baseURL"], "http://127.0.0.1:49156/openai/v1")
+	}
+	if openaiOpts["apiKey"] != "databricks-proxy" {
+		t.Errorf("databricks-openai-proxy.options.apiKey = %v, want %q",
+			openaiOpts["apiKey"], "databricks-proxy")
+	}
+}
+
+// TestPatch_OpenAIProxyModelsRegistered verifies the OpenAI provider's
+// models map is seeded with databricks-gpt-5-5. Listed inline (not from a
+// looped slice) so a typo in the implementation still fails this test.
+func TestPatch_OpenAIProxyModelsRegistered(t *testing.T) {
+	c := setupTestConfig(t)
+
+	if err := c.Patch("http://127.0.0.1:49156", "databricks-claude-opus-4-7", "databricks-proxy", false); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	m := readJSON(t, c.Path())
+	providers, _ := m["provider"].(map[string]interface{})
+	openai, _ := providers["databricks-openai-proxy"].(map[string]interface{})
+	if openai == nil {
+		t.Fatal("databricks-openai-proxy provider missing")
+	}
+	models, _ := openai["models"].(map[string]interface{})
+	if models == nil {
+		t.Fatal("databricks-openai-proxy.models missing")
+	}
+	if _, ok := models["databricks-gpt-5-5"]; !ok {
+		t.Error("models.databricks-gpt-5-5 missing")
+	}
+}
+
+// TestNeedsConfig_DetectsStaleOpenAIProxyProvider verifies that a config
+// with correct anthropic + gemini providers but missing
+// databricks-openai-proxy returns NeedsConfig=true. Upgrade trigger for
+// existing users.
+func TestNeedsConfig_DetectsStaleOpenAIProxyProvider(t *testing.T) {
+	c := setupTestConfig(t)
+
+	existing := map[string]interface{}{
+		"provider": map[string]interface{}{
+			"databricks-proxy": map[string]interface{}{
+				"npm":  "@ai-sdk/anthropic",
+				"name": "Databricks AI Gateway",
+				"options": map[string]interface{}{
+					"baseURL": "http://127.0.0.1:49156/v1",
+					"apiKey":  "databricks-proxy",
+				},
+			},
+			"databricks-gemini-proxy": map[string]interface{}{
+				"npm":  "@ai-sdk/google",
+				"name": "Databricks Gemini",
+				"options": map[string]interface{}{
+					"baseURL": "http://127.0.0.1:49156/v1beta",
+					"apiKey":  "databricks-proxy",
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(existing, "", "  ")
+	if err := os.WriteFile(c.Path(), data, 0o600); err != nil {
+		t.Fatalf("write existing config: %v", err)
+	}
+
+	if !c.NeedsConfig("http://127.0.0.1:49156") {
+		t.Fatal("NeedsConfig returned false for openai-proxy-missing config; expected true")
+	}
+
+	if err := c.Patch("http://127.0.0.1:49156", "databricks-claude-opus-4-7", "databricks-proxy", false); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	if c.NeedsConfig("http://127.0.0.1:49156") {
+		t.Error("NeedsConfig still true after Patch injected openai-proxy")
+	}
+}
+
+// TestNeedsConfig_DetectsStaleOpenAIProxyBaseURL verifies a stale openai
+// baseURL is detected as needing a rewrite even when anthropic + gemini
+// are current. Mirrors the gemini-equivalent guard.
+func TestNeedsConfig_DetectsStaleOpenAIProxyBaseURL(t *testing.T) {
+	c := setupTestConfig(t)
+
+	if err := c.Patch("http://127.0.0.1:49156", "databricks-claude-opus-4-7", "databricks-proxy", false); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+	m := readJSON(t, c.Path())
+	providers, _ := m["provider"].(map[string]interface{})
+	openai, _ := providers["databricks-openai-proxy"].(map[string]interface{})
+	openaiOpts, _ := openai["options"].(map[string]interface{})
+	openaiOpts["baseURL"] = "http://127.0.0.1:11111/openai/v1" // stale port
+	openai["options"] = openaiOpts
+	providers["databricks-openai-proxy"] = openai
+	m["provider"] = providers
+	data, _ := json.MarshalIndent(m, "", "  ")
+	if err := os.WriteFile(c.Path(), data, 0o600); err != nil {
+		t.Fatalf("write mutated config: %v", err)
+	}
+
+	if !c.NeedsConfig("http://127.0.0.1:49156") {
+		t.Fatal("NeedsConfig returned false for stale openai-proxy baseURL; expected true")
+	}
+}
+
+// TestUpdateProxyURL_UpdatesOpenAIProxyProvider verifies UpdateProxyURL
+// rewrites the openai-proxy baseURL alongside anthropic and gemini.
+func TestUpdateProxyURL_UpdatesOpenAIProxyProvider(t *testing.T) {
+	c := setupTestConfig(t)
+
+	if err := c.Patch("http://127.0.0.1:49156", "databricks-claude-opus-4-7", "databricks-proxy", false); err != nil {
+		t.Fatalf("Patch: %v", err)
+	}
+
+	if err := c.UpdateProxyURL("http://127.0.0.1:50000"); err != nil {
+		t.Fatalf("UpdateProxyURL: %v", err)
+	}
+
+	m := readJSON(t, c.Path())
+	providers, _ := m["provider"].(map[string]interface{})
+	openai, _ := providers["databricks-openai-proxy"].(map[string]interface{})
+	openaiOpts, _ := openai["options"].(map[string]interface{})
+	if openaiOpts["baseURL"] != "http://127.0.0.1:50000/openai/v1" {
+		t.Errorf("databricks-openai-proxy.options.baseURL = %v, want %q",
+			openaiOpts["baseURL"], "http://127.0.0.1:50000/openai/v1")
+	}
+}

--- a/proxy.go
+++ b/proxy.go
@@ -36,6 +36,15 @@ func NewProxyServer(config *ProxyConfig) (http.Handler, error) {
 		TLSKeyFile:        config.TLSKeyFile,
 		ToolName:          "databricks-opencode",
 		Version:           Version,
+		// ResponsesRewrite: the Databricks AI Gateway re-encodes Responses-API
+		// SSE and emits a different id in response.output_item.added (item.id)
+		// than in downstream response.output_text.* / response.content_part.*
+		// events (item_id), which trips @ai-sdk/openai's parser with
+		// "text part <id> not found". opencode is OpenAI-shaped and hits
+		// /v1/responses, so the gate is default-on here. Sibling wrappers
+		// (databricks-claude, databricks-codex, databricks-cursor) leave it
+		// false. See databricks-claude#191 / databricks-opencode#1.
+		ResponsesRewrite: proxy.ResponsesRewriteSettings{Enabled: true},
 	}
 	if config.GeminiUpstream != "" {
 		cfg.Routes = append(cfg.Routes, proxy.UpstreamRoute{

--- a/proxy.go
+++ b/proxy.go
@@ -17,6 +17,13 @@ type ProxyConfig struct {
 	// Empty string disables the route — byte-identical to the prior
 	// Anthropic-only behavior.
 	GeminiUpstream string
+	// OpenAIUpstream, when non-empty, registers a /openai/v1 path-prefix
+	// route to the Databricks OpenAI Responses AI Gateway upstream so the
+	// same local proxy port serves OpenAI Responses traffic — and so the
+	// Responses SSE rewriter (which fires on any path containing
+	// /responses) continues to apply on /openai/v1/responses. Empty string
+	// disables the route.
+	OpenAIUpstream string
 	TokenProvider  *tokencache.TokenProvider
 	Verbose        bool
 	APIKey         string
@@ -41,15 +48,24 @@ func NewProxyServer(config *ProxyConfig) (http.Handler, error) {
 		// than in downstream response.output_text.* / response.content_part.*
 		// events (item_id), which trips @ai-sdk/openai's parser with
 		// "text part <id> not found". opencode is OpenAI-shaped and hits
-		// /v1/responses, so the gate is default-on here. Sibling wrappers
-		// (databricks-claude, databricks-codex, databricks-cursor) leave it
-		// false. See databricks-claude#191 / databricks-opencode#1.
+		// /v1/responses on the Anthropic catch-all route AND
+		// /openai/v1/responses on the new OpenAI path-prefix route — both
+		// satisfy the rewriter's strings.Contains(path, "/responses") gate,
+		// so the gate is default-on here. Sibling wrappers (databricks-claude,
+		// databricks-codex, databricks-cursor) leave it false. See
+		// databricks-claude#191 / databricks-opencode#1.
 		ResponsesRewrite: proxy.ResponsesRewriteSettings{Enabled: true},
 	}
 	if config.GeminiUpstream != "" {
 		cfg.Routes = append(cfg.Routes, proxy.UpstreamRoute{
 			PathPrefix: "/v1beta",
 			Upstream:   config.GeminiUpstream,
+		})
+	}
+	if config.OpenAIUpstream != "" {
+		cfg.Routes = append(cfg.Routes, proxy.UpstreamRoute{
+			PathPrefix: "/openai/v1",
+			Upstream:   config.OpenAIUpstream,
 		})
 	}
 	return proxy.NewServer(cfg)

--- a/proxy_responses_rewrite_test.go
+++ b/proxy_responses_rewrite_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestProxy_ResponsesRewriter_EndToEnd verifies that the wrapper's proxy, with
+// ResponsesRewrite enabled by default, rewrites mismatched item_ids in
+// Responses-API SSE streams emitted by an upstream that mimics the Databricks
+// AI Gateway's re-encoding behavior.
+//
+// Regression coverage for IceRhymers/databricks-opencode#1 — the AI Gateway
+// emits `response.output_item.added` with one `item.id` but downstream
+// `response.output_text.*` / `response.content_part.*` events carry a
+// different `item_id`. @ai-sdk/openai's parser then fails with
+// `text part <id> not found`. The rewriter caches the canonical id from
+// `output_item.added` and rewrites any mismatched `item_id` on later events
+// so opencode sees a single consistent id per output_index.
+func TestProxy_ResponsesRewriter_EndToEnd(t *testing.T) {
+	// Upstream simulates the AI Gateway: emits output_item.added with the
+	// canonical id, then content_part.added / output_text.delta /
+	// output_text.done carrying a *different* id (the mismatch bug).
+	frames := []string{
+		`event: response.output_item.added` + "\n" +
+			`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"item_canonical","type":"message"}}` + "\n\n",
+		`event: response.content_part.added` + "\n" +
+			`data: {"type":"response.content_part.added","output_index":0,"item_id":"item_WRONG","part":{"type":"output_text","text":""}}` + "\n\n",
+		`event: response.output_text.delta` + "\n" +
+			`data: {"type":"response.output_text.delta","output_index":0,"item_id":"item_WRONG","delta":"hello"}` + "\n\n",
+		`event: response.output_text.done` + "\n" +
+			`data: {"type":"response.output_text.done","output_index":0,"item_id":"item_WRONG","text":"hello"}` + "\n\n",
+	}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("upstream ResponseWriter does not implement Flusher")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		for _, f := range frames {
+			_, _ = io.WriteString(w, f)
+			flusher.Flush()
+		}
+	}))
+	defer upstream.Close()
+
+	cfg := &ProxyConfig{
+		InferenceUpstream: upstream.URL,
+		TokenProvider:     warmToken("tok"),
+	}
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
+
+	l, err := StartProxy(handler, "", "")
+	if err != nil {
+		t.Fatalf("StartProxy: %v", err)
+	}
+	defer l.Close()
+
+	resp, err := http.Get("http://" + l.Addr().String() + "/v1/responses")
+	if err != nil {
+		t.Fatalf("GET /v1/responses: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	out := string(body)
+
+	if strings.Contains(out, "item_WRONG") {
+		t.Errorf("mismatched id should have been rewritten away; output still contains item_WRONG:\n%s", out)
+	}
+	// All downstream events should now carry the canonical id from the
+	// output_item.added frame.
+	if !strings.Contains(out, "item_canonical") {
+		t.Errorf("canonical id missing from rewritten output:\n%s", out)
+	}
+	// Sanity: the delta payload should still be present.
+	if !strings.Contains(out, `"delta":"hello"`) {
+		t.Errorf("delta payload missing from rewritten output:\n%s", out)
+	}
+}
+
+// TestProxy_ResponsesRewriter_NonResponsesPath verifies that requests to
+// non-Responses paths (e.g. /v1/chat/completions) are passed through
+// byte-identically — the rewriter must not interfere with other endpoints.
+func TestProxy_ResponsesRewriter_NonResponsesPath(t *testing.T) {
+	payload := `data: {"item_id":"item_WRONG"}` + "\n\n"
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("upstream ResponseWriter does not implement Flusher")
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, payload)
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	cfg := &ProxyConfig{
+		InferenceUpstream: upstream.URL,
+		TokenProvider:     warmToken("tok"),
+	}
+	handler, err := NewProxyServer(cfg)
+	if err != nil {
+		t.Fatalf("NewProxyServer: %v", err)
+	}
+
+	l, err := StartProxy(handler, "", "")
+	if err != nil {
+		t.Fatalf("StartProxy: %v", err)
+	}
+	defer l.Close()
+
+	resp, err := http.Get("http://" + l.Addr().String() + "/v1/chat/completions")
+	if err != nil {
+		t.Fatalf("GET /v1/chat/completions: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "item_WRONG") {
+		t.Errorf("non-/responses path should pass through unchanged; got:\n%s", string(body))
+	}
+}

--- a/token.go
+++ b/token.go
@@ -140,3 +140,17 @@ func ConstructGatewayURL(host string) string {
 func ConstructGeminiGatewayURL(host string) string {
 	return strings.TrimRight(host, "/") + "/ai-gateway/gemini/v1beta"
 }
+
+// ConstructOpenAIGatewayURL builds the Databricks AI Gateway URL for the
+// OpenAI Responses upstream. Format: {host}/ai-gateway/openai/v1
+//
+// The /openai/v1 segment is included so that the proxy.UpstreamRoute path
+// algebra resolves correctly: incoming /openai/v1/responses has its
+// /openai/v1 prefix stripped, then this base path is prepended, yielding
+// /ai-gateway/openai/v1/responses — the verified Databricks OpenAI
+// Responses endpoint. Routing through the local proxy is essential so the
+// Responses SSE rewriter (gated on strings.Contains(path, "/responses"))
+// continues to fire.
+func ConstructOpenAIGatewayURL(host string) string {
+	return strings.TrimRight(host, "/") + "/ai-gateway/openai/v1"
+}

--- a/token_test.go
+++ b/token_test.go
@@ -352,3 +352,39 @@ func TestConstructGeminiGatewayURL(t *testing.T) {
 		})
 	}
 }
+
+// TestConstructOpenAIGatewayURL: verifies the host-relative OpenAI
+// Responses AI Gateway URL. Includes /openai/v1 so the UpstreamRoute
+// strip-then-prepend produces the verified /ai-gateway/openai/v1/responses
+// endpoint.
+func TestConstructOpenAIGatewayURL(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{
+			name: "plain host",
+			host: "https://dbc-abc123.cloud.databricks.com",
+			want: "https://dbc-abc123.cloud.databricks.com/ai-gateway/openai/v1",
+		},
+		{
+			name: "trailing slash trimmed",
+			host: "https://dbc-abc123.cloud.databricks.com/",
+			want: "https://dbc-abc123.cloud.databricks.com/ai-gateway/openai/v1",
+		},
+		{
+			name: "multiple trailing slashes trimmed",
+			host: "https://example.databricks.com///",
+			want: "https://example.databricks.com/ai-gateway/openai/v1",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ConstructOpenAIGatewayURL(tc.host)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #95. Depends on (and consumes) IceRhymers/databricks-claude#191, released as databricks-claude v1.2.0.

## What changed

- `go.mod`: bump `github.com/IceRhymers/databricks-claude` v1.1.0 → v1.2.0; `go mod tidy` clean.
- `proxy.go` `NewProxyServer`: set `cfg.ResponsesRewrite = proxy.ResponsesRewriteSettings{Enabled: true}`. opencode is OpenAI-shaped and hits `/v1/responses`, so the gate is default-on here (sibling wrappers — databricks-claude, databricks-codex, databricks-cursor — leave it false).
- `proxy_responses_rewrite_test.go`: end-to-end integration test driving a fake upstream that mimics the Databricks AI Gateway's mismatched-id Responses-API SSE encoding, asserts the wrapper's proxy reconciles `item_id` per `output_index` to the canonical id from `output_item.added`. A second test verifies non-`/responses` paths still pass through byte-identically.

## Why

The Databricks AI Gateway re-encodes Responses-API SSE and emits a different id in `response.output_item.added` (`item.id`) than in the downstream `response.output_text.*` / `response.content_part.*` events (`item_id`), tripping `@ai-sdk/openai`'s parser with `text part <id> not found`. Fixed proxy-side rather than by forking opencode's TypeScript — see IceRhymers/opencode#1 for the original symptom.

## Verification

- `go vet ./...` clean
- `go test ./...` — all packages green, including the new integration test
- `go build ./...` clean

## Acceptance criteria (from #95)

- [x] `go.mod` pins databricks-claude v1.2.0
- [x] `ResponsesRewrite` enabled in the proxy config
- [x] Integration test proves end-to-end id rewrite through the wrapper's proxy
- [x] CI green on PR (pending)

`feat:` prefix → release-please minor bump.